### PR TITLE
Add local cannot-attend form

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -145,3 +145,42 @@ html, body {
     width: 90%;
   }
 }
+
+/* Cannot attend form styles */
+.attendance-form-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255,255,255,0.95);
+  padding: 0.8rem 1rem;
+  border-radius: var(--card-radius);
+  box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+  z-index: 3;
+  color: #222;
+  text-align: center;
+}
+.attendance-form-container h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  color: var(--emerald-border);
+}
+.attendance-form-container input {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--gray-light);
+  border-radius: var(--btn-radius);
+  margin-right: 0.4rem;
+}
+.attendance-form-container button {
+  padding: 0.35rem 0.8rem;
+  border: none;
+  border-radius: var(--btn-radius);
+  background: var(--emerald-accent);
+  color: var(--white);
+  cursor: pointer;
+}
+.attendance-form-container a {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--emerald-border);
+}

--- a/assets/js/cant-attend.js
+++ b/assets/js/cant-attend.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('cantAttendForm');
+  const msg = document.getElementById('formMessage');
+  if (form) {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const nameEl = document.getElementById('nameInput');
+      const name = nameEl.value.trim();
+      if (!name) return;
+      const list = JSON.parse(localStorage.getItem('cantAttendList') || '[]');
+      list.push({ name, timestamp: new Date().toISOString() });
+      localStorage.setItem('cantAttendList', JSON.stringify(list));
+      if (msg) msg.textContent = 'Thank you! Your response has been saved locally.';
+      form.reset();
+    });
+  }
+
+  const listContainer = document.getElementById('submissionList');
+  if (listContainer) {
+    const list = JSON.parse(localStorage.getItem('cantAttendList') || '[]');
+    if (list.length === 0) {
+      listContainer.innerHTML = '<li>No submissions yet.</li>';
+    } else {
+      list.forEach(item => {
+        const li = document.createElement('li');
+        const date = new Date(item.timestamp);
+        li.textContent = `${item.name} - ${date.toLocaleDateString()}`;
+        listContainer.appendChild(li);
+      });
+    }
+  }
+});

--- a/cant-attend-list.html
+++ b/cant-attend-list.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cannot Attend List</title>
+  <link rel="stylesheet" href="assets/css/save-the-date.css">
+</head>
+<body>
+  <h1 style="text-align:center; margin-top:2rem;">Cannot Attend Submissions</h1>
+  <ul id="submissionList" style="max-width:400px;margin:1rem auto; padding:0 1rem;"></ul>
+  <script src="assets/js/cant-attend.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,17 @@
     </div>
   </div>
 
+  <div class="attendance-form-container">
+    <h2>Can't make it?</h2>
+    <form id="cantAttendForm">
+      <input type="text" id="nameInput" placeholder="Your name" required>
+      <button type="submit">Submit</button>
+    </form>
+    <p id="formMessage"></p>
+    <a href="cant-attend-list.html">View submissions</a>
+  </div>
+
   <script src="assets/js/save-the-date.js"></script>
+  <script src="assets/js/cant-attend.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a small form so visitors can indicate they can't attend
- keep list of submissions in browser localStorage
- show list via `cant-attend-list.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68846c71c48c832eb901d9a1b63c814f