### PR TITLE
Fix can't attend button

### DIFF
--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -8,8 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const card = introCard.querySelector('.flip-card');
         if (card) {
           card.classList.add('flipped');
-          // Prevent flip interactions but allow back-side buttons to work
-          card.style.pointerEvents = 'none';
+          // Prevent further flip interactions while allowing back-side buttons
+          const front = card.querySelector('.flip-front');
+          if (front) front.style.pointerEvents = 'none';
         }
       },
       { once: true }


### PR DESCRIPTION
## Summary
- fix `Can't Attend` button click by only disabling pointer events on the front side of the card

## Testing
- `node --check assets/js/save-the-date.js`

------
https://chatgpt.com/codex/tasks/task_e_68853129dd84832eb077ab17b364b599