### PR TITLE
feat: add reusable card styling

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -77,6 +77,23 @@ html, body {
   pointer-events: auto;
 }
 
+/* base card styling */
+.card {
+  background: var(--white);
+  color: #222;
+  border-radius: var(--card-radius);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12);
+  border: 2px solid var(--emerald-border);
+  font-family: var(--font-heading);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--t-fast) var(--ease-med),
+    color var(--t-fast) var(--ease-med),
+    transform var(--t-fast) var(--ease-med),
+    opacity var(--t-med) var(--ease-med);
+}
+
 .flip-card {
   background: transparent;
   width: 320px;
@@ -100,11 +117,6 @@ html, body {
   width: 100%;
   height: 100%;
   backface-visibility: hidden;
-  background: var(--white);
-  color: #222;
-  border-radius: var(--card-radius);
-  box-shadow: 0 8px 40px rgba(0,0,0,0.12);
-  border: 1.5px solid var(--gray-light);
   padding: 2rem;
   display: flex;
   flex-direction: column;
@@ -113,7 +125,6 @@ html, body {
 }
 .flip-front:hover {
   box-shadow: 0 12px 48px rgba(1,68,33,0.18);
-  border: 2px solid var(--emerald-border);
   transform: translateY(-2px) scale(1.02);
 }
 .flip-back {
@@ -198,13 +209,9 @@ html, body {
   z-index: 2;
 }
 .thank-you-card {
-  background: var(--white);
-  color: #222;
-  border-radius: var(--card-radius);
-  box-shadow: 0 8px 40px rgba(0,0,0,0.12);
-  border: 1.5px solid var(--gray-light);
   padding: 2rem;
   max-width: 380px;
   text-align: center;
   line-height: 1.4;
+  cursor: default;
 }

--- a/index.html
+++ b/index.html
@@ -20,12 +20,12 @@
   <div class="intro-card-container" id="introCard">
     <div class="flip-card">
       <div class="flip-inner">
-        <div class="flip-front">
+        <div class="card flip-front">
           <h1 class="wedding-names">Christopher<br>&amp;<br>Lorraine</h1>
           <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
           <div id="countdown"></div>
         </div>
-        <div class="flip-back">
+        <div class="card flip-back">
           <div id="backContent">
             <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p>
             <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
@@ -48,7 +48,7 @@
 
 
   <div id="thankYouMessage" class="thank-you-container" style="display:none;">
-    <div class="thank-you-card">
+    <div class="card thank-you-card">
       <p>Thank you for submitting and we are sorry you will not be able to attend the wedding. We will email you the wedding site once it is available so you can still engage and be a part of the celebration.</p>
     </div>
   </div>

--- a/thankyou.html
+++ b/thankyou.html
@@ -17,7 +17,7 @@
   </div>
   <div class="video-overlay"></div>
   <div class="thank-you-container">
-    <div class="thank-you-card">
+    <div class="card thank-you-card">
       <p>Thank you for submitting and we are sorry you will not be able to attend the wedding. We will email you the wedding site once it is available so you can still engage and be a part of the celebration.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add base `.card` class for consistent card look and transitions
- apply new card class to flip and thank-you cards, simplifying CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e649b7918832eb1510e55867e7a52