### PR TITLE
Expand wedding card layout and adjust details

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -105,8 +105,8 @@ body {
 /* flip card structure */
 .flip-card {
   background: transparent;
-  width: 320px;
-  height: 360px;
+  width: 360px;
+  height: 420px;
   perspective: 1000px;
 }
 .flip-inner {
@@ -153,6 +153,7 @@ body {
   font-size: 1.18rem;
   color: var(--emerald-accent);
   text-align: center;
+  white-space: nowrap;
 }
 
 .flip-back p {
@@ -216,7 +217,8 @@ body {
 
 @media (max-width: 600px) {
   .flip-card {
-    width: 90%;
+    width: 95%;
+    height: 420px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <div class="flip-card">
       <div class="flip-inner">
         <div class="card flip-front">
-          <h1 class="wedding-names">Christopher<br>&amp;<br>Lorraine</h1>
+          <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
           <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
           <div id="countdown" class="flip-clock flip-small"></div>
         </div>


### PR DESCRIPTION
## Summary
- Enlarge flip card to better contain wedding details
- Keep wedding date on one line for improved readability
- Swap couple name order to display Lorraine before Christopher

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6e33afa4832ea434f7730437aa08