### PR TITLE
Style thank-you card like intro card

### DIFF
--- a/thankyou.html
+++ b/thankyou.html
@@ -1,25 +1,30 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <title>Thank You</title>
-  <link rel="icon" type="image/png" href="assets/images/favicon.png">
-  <link rel="stylesheet" href="assets/css/save-the-date.css">
-</head>
-<body class="no-scroll">
-  <div class="background-video">
-    <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
-      <source src="assets/video.mp4" type="video/mp4">
-      <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
-    </video>
-  </div>
-  <div class="video-overlay"></div>
-  <div class="thank-you-container">
-    <div class="thank-you-card">
-      <p>Thank you for submitting and we are sorry you will not be able to attend the wedding. We will email you the wedding site once it is available so you can still engage and be a part of the celebration.</p>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <title>Thank You</title>
+    <link rel="icon" type="image/png" href="assets/images/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap" onload="this.rel='stylesheet'" />
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap" />
+    </noscript>
+    <link rel="stylesheet" href="assets/css/save-the-date.css" />
+  </head>
+  <body class="no-scroll">
+    <div class="background-video">
+      <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
+        <source src="assets/video.mp4" type="video/mp4" />
+        <img src="assets/video-fallback.jpg" alt="Christopher & Lorraine" style="width: 100%; height: 100%; object-fit: cover" loading="lazy" />
+      </video>
     </div>
-  </div>
-</body>
+    <div class="video-overlay"></div>
+    <div class="intro-card-container visible">
+      <div class="card">
+        <p>Thank you for submitting and we are sorry you will not be able to attend the wedding. We will email you the wedding site once it is available so you can still engage and be a part of the celebration.</p>
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Load web fonts and shared styles on thank-you page
- Reuse intro card markup so thank-you message matches site look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8d297390832ea2188f7e3357a249