### PR TITLE
Consolidate background video styles

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -40,30 +40,6 @@ body {
   box-sizing: border-box;
 }
 
-/* video background */
-.background-video {
-  position: fixed;
-  inset: 0;
-  overflow: hidden;
-  z-index: 0;
-}
-.background-video video {
-  position: absolute;
-  inset: 0;
-  object-fit: cover;
-  transition: opacity var(--t-med) var(--ease-med);
-  background: var(--bg-emerald-dark);
-}
-
-/* overlay */
-.video-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--emerald-overlay);
-  z-index: 1;
-  pointer-events: none;
-}
-
 /* base card styling */
 .card {
   background: var(--white);
@@ -183,6 +159,7 @@ body {
   height: 100%;
   object-fit: cover;
   transition: opacity var(--t-med) var(--ease-med);
+  background: var(--bg-emerald-dark);
 }
 
 /* Dim overlay */


### PR DESCRIPTION
## Summary
- Merge duplicated `.background-video` rules into a single block scoped to the intro page.
- Retain fallback image and color while removing redundant declarations.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9203ac38832eac56758b569f6e6d