### PR TITLE
Specify non-submitting button for can't attend link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                 Our full website is coming soon. Please plan ahead and let
                 Chris and Lorraine know if you need help.
               </p>
-              <button id="showCantAttendForm" class="cant-attend-btn">
+              <button type="button" id="showCantAttendForm" class="cant-attend-btn">
                 Can't attend?
               </button>
             </div>


### PR DESCRIPTION
## Summary
- Ensure "Can't attend?" trigger button is of type="button" to avoid implicit form submission.

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
html=open('index.html').read()
class MyParser(HTMLParser):
    def handle_starttag(self, tag, attrs):
        if tag=='button' and dict(attrs).get('id')=='showCantAttendForm':
            print('Button attrs:', dict(attrs))
parser=MyParser(); parser.feed(html)
PY`
- `python3 - <<'PY'
from html.parser import HTMLParser
html=open('index.html').read()
stack=[]
class MyParser(HTMLParser):
    def handle_starttag(self, tag, attrs):
        stack.append(tag)
        if tag=='button' and dict(attrs).get('id')=='showCantAttendForm':
            print('Button stack:', stack)
    def handle_endtag(self, tag):
        if stack and stack[-1]==tag:
            stack.pop()
parser=MyParser(); parser.feed(html)
PY`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e9212d5e0832eae26a5b5971dab6c