### PR TITLE
Fix background fallback image path

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -172,7 +172,7 @@ body {
 .background-video {
   position: fixed;
   inset: 0;
-  background: url("assets/video-fallback.jpg") center/cover no-repeat;
+  background: url("../video-fallback.jpg") center/cover no-repeat;
   overflow: hidden;
   z-index: 0;
 }


### PR DESCRIPTION
## Summary
- fix CSS fallback image path for background video

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e921e8b5c832e828f48d4785334b2