### PR TITLE
Resize intro card to fit content and keep date line intact

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -131,6 +131,7 @@ html, body {
   margin-bottom: 2.3rem;
   letter-spacing: .04em;
   text-align: center;
+  white-space: nowrap;
 }
 
 .flip-back p {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -1,6 +1,21 @@
 document.addEventListener('DOMContentLoaded', () => {
   const introCard = document.getElementById('introCard');
   if (introCard) {
+    const flipCard = introCard.querySelector('.flip-card');
+    const front = flipCard?.querySelector('.flip-front');
+    const back = flipCard?.querySelector('.flip-back');
+
+    const adjustCardSize = () => {
+      if (!flipCard || !front || !back) return;
+      const width = Math.max(front.scrollWidth, back.scrollWidth);
+      const height = Math.max(front.scrollHeight, back.scrollHeight);
+      flipCard.style.width = `${width}px`;
+      flipCard.style.height = `${height}px`;
+    };
+
+    adjustCardSize();
+    window.addEventListener('resize', adjustCardSize);
+
     setTimeout(() => introCard.classList.add('visible'), 3000);
     introCard.addEventListener('click', () => {
       introCard.querySelector('.flip-card')?.classList.toggle('flipped');


### PR DESCRIPTION
## Summary
- Dynamically size the intro flip card to accommodate all content
- Prevent date and location from wrapping by enforcing no-wrap styling

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ecdbb0590832e84d1741f6f8f85a5