### PR TITLE
style: apply emerald theme styling and lock flipped card

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -114,6 +114,8 @@ html, body {
 }
 .flip-back {
   transform: rotateY(180deg);
+  color: var(--emerald-border);
+  font-family: var(--font-body);
 }
 
 .wedding-names {
@@ -143,7 +145,7 @@ html, body {
 /* Form displayed inside the intro card when user cannot attend */
 .card-form-container {
   display: none;
-  color: #222;
+  color: var(--emerald-border);
   text-align: center;
 }
 .card-form-container input {
@@ -154,11 +156,12 @@ html, body {
 }
 button {
   padding: 0.4rem 0.8rem;
-  border: none;
+  border: 1px solid var(--emerald-border);
   border-radius: var(--btn-radius);
   background: var(--emerald-accent);
   color: var(--white);
   cursor: pointer;
+  font-family: var(--font-body);
 }
 
 @media (max-width: 600px) {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -17,9 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('resize', adjustCardSize);
 
     setTimeout(() => introCard.classList.add('visible'), 3000);
-    introCard.addEventListener('click', () => {
-      introCard.querySelector('.flip-card')?.classList.toggle('flipped');
-    });
+    const handleFlip = () => {
+      introCard.querySelector('.flip-card')?.classList.add('flipped');
+      introCard.removeEventListener('click', handleFlip);
+    };
+    introCard.addEventListener('click', handleFlip);
   }
 
   const countdownEl = document.getElementById('countdown');


### PR DESCRIPTION
## Summary
- style back of intro card and buttons with emerald fonts and borders
- prevent further flips after intro card is clicked once

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed17bc240832ea1580428e8273856