### PR TITLE
Add animated countdown before intro flip card

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -204,3 +204,35 @@ button:hover {
   text-align: center;
   line-height: 1.4;
 }
+
+/* Intro countdown overlay */
+.countdown-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.countdown-number {
+  font-family: var(--font-heading);
+  color: var(--white);
+  animation: fade-grow 1s forwards;
+  font-size: 4rem;
+}
+
+@keyframes fade-grow {
+  0% {
+    opacity: 0;
+    transform: scale(0.2);
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(20);
+  }
+}

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const introCard = document.getElementById('introCard');
+  const launchCountdown = document.getElementById('launchCountdown');
   if (introCard) {
     const flipCard = introCard.querySelector('.flip-card');
     const front = flipCard?.querySelector('.flip-front');
@@ -16,7 +17,29 @@ document.addEventListener('DOMContentLoaded', () => {
     adjustCardSize();
     window.addEventListener('resize', adjustCardSize);
 
-    setTimeout(() => introCard.classList.add('visible'), 3000);
+    const showIntroCard = () => introCard.classList.add('visible');
+
+    if (launchCountdown) {
+      let count = 10;
+      const runCountdown = () => {
+        if (count === 0) {
+          launchCountdown.remove();
+          showIntroCard();
+          return;
+        }
+        launchCountdown.innerHTML = '';
+        const numEl = document.createElement('div');
+        numEl.className = 'countdown-number';
+        numEl.textContent = count;
+        launchCountdown.appendChild(numEl);
+        count--;
+        setTimeout(runCountdown, 1000);
+      };
+      runCountdown();
+    } else {
+      setTimeout(showIntroCard, 3000);
+    }
+
     introCard.addEventListener('click', () => {
       introCard.querySelector('.flip-card')?.classList.toggle('flipped');
     });
@@ -33,8 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       const days = Math.floor(diff / (1000*60*60*24));
-      const hours = Math.floor((diff/ (1000*60*60)) % 24);
-      const minutes = Math.floor((diff/ (1000*60)) % 60);
+      const hours = Math.floor((diff / (1000*60*60)) % 24);
+      const minutes = Math.floor((diff / (1000*60)) % 60);
       const seconds = Math.floor((diff/1000) % 60);
       countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
     }, 1000);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="assets/css/save-the-date.css">
 </head>
 <body class="no-scroll">
+  <div id="launchCountdown" class="countdown-overlay"></div>
   <div class="background-video">
     <video autoplay muted loop playsinline poster="../assets/video-fallback.jpg">
       <source src="../assets/video.mp4" type="video/mp4">


### PR DESCRIPTION
## Summary
- Add full-screen overlay displaying numbers 10 to 1 that fade in and scale beyond the screen.
- Show the intro flip card only after the countdown completes.
- Style and animate countdown numbers with new CSS keyframes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed1c6cf30832ebe4bbebdaa9f082b