### PR TITLE
Show loading indicator for slow submit action

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -187,6 +187,31 @@ button:hover {
   background: var(--emerald-hover);
 }
 
+/* Loading state for submit buttons */
+button.loading {
+  position: relative;
+  opacity: 0.7;
+  cursor: wait;
+}
+button.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border: 2px solid var(--white);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Thank you page styles */
 .thank-you-container {
   position: fixed;

--- a/assets/js/cant-attend.js
+++ b/assets/js/cant-attend.js
@@ -14,15 +14,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (form && introCard && thankYou) {
+    const submitButton = form.querySelector('button[type="submit"]');
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const formData = new FormData(form);
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.classList.add('loading');
+        submitButton.textContent = 'Sending...';
+      }
       try {
         await fetch(form.action, { method: 'POST', body: formData, mode: 'no-cors' });
         introCard.remove();
         thankYou.style.display = 'flex';
       } catch (err) {
         formContainer.innerHTML = '<p class="thank-you-message">Submission failed. Please try again later.</p>';
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.classList.remove('loading');
+          submitButton.textContent = 'Send';
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- Add CSS loading state with spinner for buttons
- Disable and show loading state on Can't Attend form submission

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed34fd6a4832e8e1f9150aba3c3ef