### PR TITLE
Expand entry card buffer

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -75,8 +75,8 @@ html, body {
 
 .flip-card {
   background: transparent;
-  width: 320px;
-  height: 360px;
+  width: 340px;
+  height: 380px;
   perspective: 1000px;
 }
 .flip-inner {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -7,8 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const adjustCardSize = () => {
       if (!flipCard || !front || !back) return;
-      const width = Math.max(front.scrollWidth, back.scrollWidth);
-      const height = Math.max(front.scrollHeight, back.scrollHeight);
+      const buffer = 20; // Add extra space to prevent text from spilling over
+      const width = Math.max(front.scrollWidth, back.scrollWidth) + buffer;
+      const height = Math.max(front.scrollHeight, back.scrollHeight) + buffer;
       flipCard.style.width = `${width}px`;
       flipCard.style.height = `${height}px`;
     };


### PR DESCRIPTION
## Summary
- enlarge default flip-card size to avoid text bleed
- adjust measured card size in JS by adding extra buffer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed4355e90832ea5d466f7184d79ad