### PR TITLE
Add countdown demo page with animated scaling numbers

### DIFF
--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('countdownDemo');
+  if (!el) return;
+  let n = 10;
+  let timer;
+  const render = () => {
+    el.textContent = n;
+    el.style.fontFamily = 'var(--font-heading)';
+    el.style.transition = 'font-size 0.7s var(--ease-med)';
+    el.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+    if (n === 1) {
+      clearInterval(timer);
+    } else {
+      n--;
+    }
+  };
+  render();
+  timer = setInterval(render, 1000);
+});

--- a/countdown.html
+++ b/countdown.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Countdown Demo</title>
+  <link rel="icon" type="image/png" href="assets/images/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap" />
+  </noscript>
+  <link rel="stylesheet" href="assets/css/save-the-date.css" />
+</head>
+<body class="no-scroll">
+  <div class="background-video">
+    <video autoplay muted loop playsinline poster="../assets/video-fallback.jpg">
+      <source src="../assets/video.mp4" type="video/mp4" />
+      <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
+    </video>
+  </div>
+  <div class="video-overlay"></div>
+  <div class="intro-card-container visible">
+    <div id="countdownDemo"></div>
+  </div>
+  <script src="assets/js/countdown-demo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `countdown.html` to demonstrate countdown functionality with existing wedding site styling and background
- Implement `countdown-demo.js` to count down from 10 to 1, enlarging text size on each step

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed53a30e0832eb1c66a0d1704efc1