### PR TITLE
Fix intro card hover blur

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -110,7 +110,7 @@ html, body {
 .flip-front:hover {
   box-shadow: 0 12px 48px rgba(1,68,33,0.18);
   border: 2px solid var(--emerald-border);
-  transform: translateY(-2px) scale(1.02);
+  transform: translateY(-2px);
 }
 .flip-back {
   transform: rotateY(180deg);


### PR DESCRIPTION
## Summary
- remove scale transform on intro card hover to keep text crisp

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed591f568832e81d84f3e1640b2eb