### PR TITLE
Add pre-roll countdown before video and intro card

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -57,6 +57,25 @@ html, body {
   pointer-events: none;
 }
 
+.countdown-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-emerald-dark);
+  color: var(--white);
+  z-index: 3;
+  font-family: var(--font-heading);
+  font-size: 5rem;
+  transition: opacity var(--t-med) var(--ease-med);
+}
+
+.countdown-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .intro-card-container {
   position: fixed;
   inset: 0;

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -1,5 +1,36 @@
 document.addEventListener('DOMContentLoaded', () => {
   const introCard = document.getElementById('introCard');
+  const video = document.querySelector('.background-video video');
+  const preCountdown = document.getElementById('preCountdown');
+
+  if (video) {
+    video.addEventListener('ended', () => {
+      introCard?.classList.add('visible');
+    });
+  }
+
+  if (preCountdown) {
+    let n = 10;
+    let timer;
+    const render = () => {
+      preCountdown.textContent = n;
+      preCountdown.style.fontFamily = 'var(--font-heading)';
+      preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
+      preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+      if (n === 1) {
+        clearInterval(timer);
+        preCountdown.classList.add('hidden');
+        video?.play();
+      } else {
+        n--;
+      }
+    };
+    render();
+    timer = setInterval(render, 1000);
+  } else {
+    video?.play();
+  }
+
   if (introCard) {
     const flipCard = introCard.querySelector('.flip-card');
     const front = flipCard?.querySelector('.flip-front');
@@ -17,7 +48,6 @@ document.addEventListener('DOMContentLoaded', () => {
     adjustCardSize();
     window.addEventListener('resize', adjustCardSize);
 
-    setTimeout(() => introCard.classList.add('visible'), 3000);
     const handleFlip = () => {
       introCard.querySelector('.flip-card')?.classList.add('flipped');
       introCard.removeEventListener('click', handleFlip);

--- a/index.html
+++ b/index.html
@@ -13,8 +13,9 @@
   <link rel="stylesheet" href="assets/css/save-the-date.css">
 </head>
 <body class="no-scroll">
+  <div id="preCountdown" class="countdown-overlay"></div>
   <div class="background-video">
-    <video autoplay muted loop playsinline poster="../assets/video-fallback.jpg">
+    <video muted playsinline preload="auto" poster="../assets/video-fallback.jpg">
       <source src="../assets/video.mp4" type="video/mp4">
       <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
     </video>


### PR DESCRIPTION
## Summary
- Add countdown overlay to index page and delay video playback until countdown completes
- Play video once and display intro card when video finishes
- Style countdown overlay for full-screen display

## Testing
- `node --check assets/js/save-the-date.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed7444be4832eb4663b9e00a26eb0