### PR TITLE
Show final count and add intro spin

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -92,6 +92,14 @@ html, body {
   pointer-events: auto;
 }
 
+.intro-card-container .flip-card {
+  transform: scale(0) rotate(-360deg);
+}
+
+.intro-card-container.visible .flip-card {
+  animation: spinIn var(--t-med) var(--ease-med) forwards;
+}
+
 .flip-card {
   background: transparent;
   width: 340px;
@@ -228,6 +236,15 @@ button.loading::after {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes spinIn {
+  from {
+    transform: scale(0) rotate(-360deg);
+  }
+  to {
+    transform: scale(1) rotate(0deg);
   }
 }
 

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -17,13 +17,14 @@ document.addEventListener('DOMContentLoaded', () => {
       preCountdown.style.fontFamily = 'var(--font-heading)';
       preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
       preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
-      if (n === 1) {
+      if (n <= 1) {
         clearInterval(timer);
-        preCountdown.classList.add('hidden');
-        video?.play();
-      } else {
-        n--;
+        setTimeout(() => {
+          preCountdown.classList.add('hidden');
+          video?.play();
+        }, 500);
       }
+      n--;
     };
     render();
     timer = setInterval(render, 1000);


### PR DESCRIPTION
## Summary
- Ensure pre-video countdown visibly reaches one and pause before starting playback
- Add spin-in animation scaling intro card from small to full size

## Testing
- `node --check assets/js/save-the-date.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edc5bfdc8832eb7350a495842eb2b