### PR TITLE
Add heartbeat sound to countdown

### DIFF
--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -3,11 +3,29 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!el) return;
   let n = 10;
   let timer;
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  const playBeat = () => {
+    const ctx = audioCtx;
+    if (ctx.state === 'suspended') ctx.resume();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(80, ctx.currentTime);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    const now = ctx.currentTime;
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(1, now + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc.start(now);
+    osc.stop(now + 0.3);
+  };
   const render = () => {
     el.textContent = n;
     el.style.fontFamily = 'var(--font-heading)';
     el.style.transition = 'font-size 0.7s var(--ease-med)';
     el.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+    playBeat();
     if (n === 1) {
       clearInterval(timer);
     } else {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -2,6 +2,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const introCard = document.getElementById('introCard');
   const video = document.querySelector('.background-video video');
   const preCountdown = document.getElementById('preCountdown');
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  const playBeat = () => {
+    const ctx = audioCtx;
+    if (ctx.state === 'suspended') ctx.resume();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(80, ctx.currentTime);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    const now = ctx.currentTime;
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(1, now + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc.start(now);
+    osc.stop(now + 0.3);
+  };
 
   if (video) {
     video.addEventListener('ended', () => {
@@ -17,6 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
       preCountdown.style.fontFamily = 'var(--font-heading)';
       preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
       preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+      playBeat();
       if (n <= 1) {
         clearInterval(timer);
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- Add Web Audio API beat effect that plays with each countdown tick
- Integrate heartbeat sound into main and demo countdown scripts

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edeb86d9c832e8491910768ab620d