### PR TITLE
Style card back text and buttons

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -141,7 +141,7 @@ html, body {
 }
 .flip-back {
   transform: rotateY(180deg);
-  color: var(--emerald-border);
+  color: var(--bg-emerald-dark);
   font-family: var(--font-body);
 }
 
@@ -172,20 +172,23 @@ html, body {
 /* Form displayed inside the intro card when user cannot attend */
 .card-form-container {
   display: none;
-  color: var(--emerald-border);
+  color: var(--bg-emerald-dark);
   text-align: center;
+  font-family: var(--font-body);
 }
 .card-form-container input {
   padding: 0.35rem 0.6rem;
   border: 1px solid var(--gray-light);
   border-radius: var(--btn-radius);
   margin-right: 0.4rem;
+  color: var(--bg-emerald-dark);
+  font-family: var(--font-body);
 }
 button {
   padding: 0.4rem 0.8rem;
-  border: 1px solid var(--emerald-border);
+  border: none;
   border-radius: var(--btn-radius);
-  background: var(--emerald-accent);
+  background: var(--bg-emerald-dark);
   color: var(--white);
   cursor: pointer;
   font-family: var(--font-body);
@@ -211,7 +214,7 @@ button {
   text-decoration: none;
 }
 button:hover {
-  background: var(--emerald-hover);
+  background: var(--bg-emerald-dark);
 }
 
 /* Loading state for submit buttons */


### PR DESCRIPTION
## Summary
- Apply emerald background and Spectral font to flip-card back content.
- Remove borders and style both "Can't Attend" and form submit buttons with the same emerald hue.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edfb012d0832eb222d39dab0ceeb0