### PR TITLE
Prevent multiple form submissions during send

### DIFF
--- a/assets/js/cant-attend.js
+++ b/assets/js/cant-attend.js
@@ -15,8 +15,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (form && introCard && thankYou) {
     const submitButton = form.querySelector('button[type="submit"]');
+    let isSubmitting = false;
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
+      if (isSubmitting) return;
+      isSubmitting = true;
       const formData = new FormData(form);
       if (submitButton) {
         submitButton.disabled = true;
@@ -34,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
           submitButton.classList.remove('loading');
           submitButton.textContent = 'Send';
         }
+        isSubmitting = false;
       }
     });
   }


### PR DESCRIPTION
## Summary
- prevent repeated 'Can't Attend' form submissions by guarding against double clicks while sending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee228f628832e9f70e5b0cfb20b5c