### PR TITLE
Require user interaction to start video with audio

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -71,6 +71,10 @@ html, body {
   transition: opacity var(--t-med) var(--ease-med);
 }
 
+.countdown-overlay.start-prompt {
+  cursor: pointer;
+}
+
 .countdown-overlay.hidden {
   opacity: 0;
   pointer-events: none;

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -26,28 +26,38 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (preCountdown) {
-    let n = 10;
-    let timer;
-    const render = () => {
-      preCountdown.textContent = n;
-      preCountdown.style.fontFamily = 'var(--font-heading)';
-      preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
-      preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
-      playBeat();
-      if (n <= 1) {
-        clearInterval(timer);
-        setTimeout(() => {
-          preCountdown.classList.add('hidden');
-          video?.play();
-        }, 500);
-      }
-      n--;
+  if (preCountdown && video) {
+    preCountdown.textContent = 'Tap to Start';
+    preCountdown.classList.add('start-prompt');
+    const start = () => {
+      audioCtx.resume();
+      preCountdown.classList.remove('start-prompt');
+      preCountdown.removeEventListener('click', start);
+      let n = 10;
+      let timer;
+      const render = () => {
+        preCountdown.textContent = n;
+        preCountdown.style.fontFamily = 'var(--font-heading)';
+        preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
+        preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+        playBeat();
+        if (n <= 1) {
+          clearInterval(timer);
+          setTimeout(() => {
+            preCountdown.classList.add('hidden');
+            video.muted = false;
+            video.play();
+          }, 500);
+        }
+        n--;
+      };
+      render();
+      timer = setInterval(render, 1000);
     };
-    render();
-    timer = setInterval(render, 1000);
-  } else {
-    video?.play();
+    preCountdown.addEventListener('click', start);
+  } else if (video) {
+    video.muted = false;
+    video.play();
   }
 
   if (introCard) {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <body class="no-scroll">
   <div id="preCountdown" class="countdown-overlay"></div>
   <div class="background-video">
-    <video muted playsinline preload="auto" poster="../assets/video-fallback.jpg">
+    <video playsinline preload="auto" poster="../assets/video-fallback.jpg">
       <source src="../assets/video.mp4" type="video/mp4">
       <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
     </video>


### PR DESCRIPTION
## Summary
- Add click-to-start overlay that resumes audio context, runs countdown, and plays video with sound
- Remove `muted` attribute from background video so users can hear audio
- Style countdown overlay to show pointer cursor when prompting for interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee25cd8f0832eb16933140cd99cc2