### PR TITLE
Improve media handling and mobile support

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -29,6 +29,10 @@ html, body {
   color: var(--white);
 }
 
+.no-scroll {
+  overflow: hidden;
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
 }
@@ -201,6 +205,7 @@ button {
 @media (max-width: 600px) {
   .flip-card {
     width: 90%;
+    height: auto;
   }
 }
 

--- a/countdown.html
+++ b/countdown.html
@@ -15,9 +15,9 @@
 </head>
 <body class="no-scroll">
   <div class="background-video">
-    <video autoplay muted loop playsinline poster="../assets/video-fallback.jpg">
-      <source src="../assets/video.mp4" type="video/mp4" />
-      <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
+    <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
+      <source src="assets/video.mp4" type="video/mp4" />
+      <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
     </video>
   </div>
   <div class="video-overlay"></div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Save the Date</title>
-  <link rel="icon" type="image/png" href="../assets/images/favicon.png">
+  <link rel="icon" type="image/png" href="assets/images/favicon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap" onload="this.rel='stylesheet'">
@@ -15,9 +15,9 @@
 <body class="no-scroll">
   <div id="preCountdown" class="countdown-overlay"></div>
   <div class="background-video">
-    <video playsinline preload="auto" poster="../assets/video-fallback.jpg">
-      <source src="../assets/video.mp4" type="video/mp4">
-      <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
+    <video playsinline muted preload="auto" poster="assets/video-fallback.jpg">
+      <source src="assets/video.mp4" type="video/mp4">
+      <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
     </video>
   </div>
   <div class="video-overlay"></div>


### PR DESCRIPTION
## Summary
- Fix video asset paths and enable muted playback for better mobile compatibility
- Boost countdown beep volume and ensure full video volume
- Add no-scroll helper class and adjust flip card sizing on small screens
- Prime video playback on user interaction and add autoplay fallback on click

## Testing
- `node --check assets/js/save-the-date.js assets/js/cant-attend.js assets/js/countdown-demo.js`
- `npx htmlhint index.html countdown.html thankyou.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ee65f4014832e8fb962fb50245ced