### PR TITLE
Adjust intro card sizing on mobile

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -207,6 +207,15 @@ button {
     width: 90%;
     height: auto;
   }
+  .wedding-names {
+    font-size: 2rem;
+  }
+  .wedding-date {
+    font-size: 1rem;
+  }
+  .countdown-overlay {
+    font-size: 3rem;
+  }
 }
 
 

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -52,7 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
         preCountdown.textContent = n;
         preCountdown.style.fontFamily = 'var(--font-heading)';
         preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
-        preCountdown.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+        const base = window.innerWidth < 600 ? 0.35 : 0.5;
+        preCountdown.style.fontSize = `${(11 - n) * (11 - n) * base}rem`;
         playBeat();
         if (n <= 1) {
           clearInterval(timer);
@@ -100,6 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     adjustCardSize();
     window.addEventListener('resize', adjustCardSize);
+    document.fonts?.ready.then(adjustCardSize);
 
     const handleFlip = () => {
       introCard.querySelector('.flip-card')?.classList.add('flipped');


### PR DESCRIPTION
## Summary
- ensure intro card sizes correctly after fonts load
- tweak countdown overlay font scaling for small screens
- shrink wedding names, date, and tap-to-start text on mobile

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc3992720832e93da0751ea8381d0