### PR TITLE
Fix initial countdown animation

### DIFF
--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const el = document.getElementById('countdownDemo');
   if (!el) return;
   let n = 10;
-  let timer;
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   const playBeat = () => {
     const ctx = audioCtx;
@@ -20,18 +19,25 @@ document.addEventListener('DOMContentLoaded', () => {
     osc.start(now);
     osc.stop(now + 0.3);
   };
-  const render = () => {
-    el.textContent = n;
-    el.style.fontFamily = 'var(--font-heading)';
+  const sizeFor = (val) => `${(11 - val) * (11 - val) * 0.5}rem`;
+
+  el.textContent = n;
+  el.style.fontFamily = 'var(--font-heading)';
+  el.style.fontSize = sizeFor(n);
+  playBeat();
+
+  // Enable transition after the initial size is applied so 10 doesn't animate
+  requestAnimationFrame(() => {
     el.style.transition = 'font-size 0.7s var(--ease-med)';
-    el.style.fontSize = `${(11 - n) * (11 - n) * 0.5}rem`;
+  });
+
+  const timer = setInterval(() => {
+    n--;
+    el.textContent = n;
+    el.style.fontSize = sizeFor(n);
     playBeat();
     if (n === 1) {
       clearInterval(timer);
-    } else {
-      n--;
     }
-  };
-  render();
-  timer = setInterval(render, 1000);
+  }, 1000);
 });

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -47,12 +47,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       let n = 10;
-      let timer;
-      const render = () => {
-        preCountdown.textContent = n;
-        preCountdown.style.fontFamily = 'var(--font-heading)';
+      const base = window.innerWidth < 600 ? 0.35 : 0.5;
+      preCountdown.style.fontFamily = 'var(--font-heading)';
+      preCountdown.textContent = n;
+      preCountdown.style.fontSize = `${(11 - n) * (11 - n) * base}rem`;
+      playBeat();
+
+      // Enable transition after initial size is applied so first number doesn't animate
+      requestAnimationFrame(() => {
         preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
-        const base = window.innerWidth < 600 ? 0.35 : 0.5;
+      });
+
+      const timer = setInterval(() => {
+        n--;
+        preCountdown.textContent = n;
         preCountdown.style.fontSize = `${(11 - n) * (11 - n) * base}rem`;
         playBeat();
         if (n <= 1) {
@@ -64,10 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
             video.play();
           }, 500);
         }
-        n--;
-      };
-      render();
-      timer = setInterval(render, 1000);
+      }, 1000);
     };
     preCountdown.addEventListener('click', start);
   } else if (video) {


### PR DESCRIPTION
## Summary
- Prevent first countdown number from animating by applying transition after setting its initial size
- Update demo and main scripts to use the new countdown flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc77e62b4832e806d98efe7cba6b8