### PR TITLE
Fix mobile card layout on initial load

### DIFF
--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -106,6 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     adjustCardSize();
     window.addEventListener('resize', adjustCardSize);
+    window.addEventListener('load', adjustCardSize);
     document.fonts?.ready.then(adjustCardSize);
 
     const handleFlip = () => {


### PR DESCRIPTION
## Summary
- Ensure intro card dimensions are recalculated when the page fully loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd1c30478832eb78a7977e49e4272