### PR TITLE
Animate countdown with cascading photo reveal

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -44,6 +44,24 @@ html, body {
   overflow: hidden;
   z-index: 0;
 }
+.background-video .countdown-image-stack {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1;
+}
+.countdown-image-stack::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0,0,0,0.38) 0%, rgba(0,0,0,0.18) 55%, rgba(0,0,0,0.42) 100%);
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.countdown-image-stack.is-active::after {
+  opacity: 1;
+}
 .background-video video {
   position: absolute;
   inset: 0;
@@ -51,6 +69,70 @@ html, body {
   height: 100%;
   object-fit: cover;
   transition: opacity var(--t-med) var(--ease-med);
+}
+.countdown-image {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(220px, 58vw, 540px);
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  filter: drop-shadow(0 24px 50px rgba(0,0,0,0.38));
+  transform-origin: center;
+  will-change: transform, opacity;
+}
+.countdown-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 28px;
+  background: rgba(0,0,0,0.18);
+  filter: blur(25px);
+  opacity: 0;
+  transform: translate3d(0,0,-1px);
+  transition: opacity 0.4s ease;
+}
+.countdown-image img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 28px;
+  object-fit: cover;
+  transform: translate(calc(var(--tx, 0px)), calc(var(--ty, 0px))) scale(1.22) rotate(var(--tilt-start, 0deg));
+  opacity: 0;
+}
+.countdown-image.active::before {
+  opacity: 1;
+}
+.countdown-image.active img {
+  animation: countdownHit var(--hit-duration, 0.6s) cubic-bezier(0.36, 0, 0.07, 1.03) forwards;
+}
+.countdown-image-stack.fade-out .countdown-image {
+  opacity: 0;
+  transition: opacity 0.8s ease, transform 0.9s ease;
+  transform: translate(-50%, -50%) scale(1.05);
+}
+.countdown-image-stack.fade-out .countdown-image::before {
+  opacity: 0;
+}
+
+@keyframes countdownHit {
+  0% {
+    opacity: 0;
+    transform: translate(calc(var(--tx, 0px)), calc(var(--ty, 0px))) scale(1.18) rotate(var(--tilt-start, 0deg));
+  }
+  28% {
+    opacity: 1;
+    transform: translate(calc(var(--tx, 0px) * 0.35), calc(var(--ty, 0px) * 0.35)) scale(0.94) rotate(var(--tilt-start, 0deg));
+  }
+  52% {
+    opacity: 1;
+    transform: translate(calc(var(--tx, 0px) * 0.18), calc(var(--ty, 0px) * 0.18)) scale(1.02) rotate(var(--tilt-mid, 0deg));
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1) rotate(0deg);
+  }
 }
 
 .video-overlay {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -2,6 +2,47 @@ document.addEventListener('DOMContentLoaded', () => {
   const introCard = document.getElementById('introCard');
   const video = document.querySelector('.background-video video');
   const preCountdown = document.getElementById('preCountdown');
+  const countdownImagesContainer = document.getElementById('countdownImages');
+  const countdownImageSources = [
+    'assets/images/_AUG4670_bw.jpg',
+    'assets/images/_AUG4710_bw.jpg',
+    'assets/images/_AUG4726_bw.jpg',
+    'assets/images/_AUG4738_bw.jpg',
+    'assets/images/_AUG4759_bw.jpg',
+    'assets/images/_AUG5106_bw.jpg',
+    'assets/images/_AUG5127_bw.jpg',
+    'assets/images/_AUG5139_bw.jpg',
+    'assets/images/_AUG5177_bw.jpg',
+    'assets/images/_AUG5181_bw.jpg',
+    'assets/images/_AUG5201_bw.jpg',
+    'assets/images/_AUG5253_bw.jpg',
+    'assets/images/_AUG5279_bw.jpg',
+    'assets/images/_AUG5290_bw.jpg',
+    'assets/images/_AUG5306_bw.jpg',
+    'assets/images/_AUG5329_bw.jpg'
+  ];
+  const countdownFrames = [];
+  const randomBetween = (min, max) => Math.random() * (max - min) + min;
+
+  if (countdownImagesContainer) {
+    countdownImageSources.forEach((src) => {
+      const frame = document.createElement('div');
+      frame.className = 'countdown-image';
+      frame.style.setProperty('--tx', `${randomBetween(-38, 38).toFixed(2)}px`);
+      frame.style.setProperty('--ty', `${randomBetween(-48, 48).toFixed(2)}px`);
+      const tilt = randomBetween(-7, 7);
+      frame.style.setProperty('--tilt-start', `${tilt.toFixed(2)}deg`);
+      frame.style.setProperty('--tilt-mid', `${(tilt * 0.35).toFixed(2)}deg`);
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = 'Lorraine and Christopher';
+      img.loading = 'eager';
+      img.decoding = 'async';
+      frame.appendChild(img);
+      countdownImagesContainer.appendChild(frame);
+      countdownFrames.push(frame);
+    });
+  }
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   const playBeat = () => {
     const ctx = audioCtx;
@@ -34,6 +75,11 @@ document.addEventListener('DOMContentLoaded', () => {
       preCountdown.classList.remove('start-prompt');
       preCountdown.removeEventListener('click', start);
 
+      if (countdownImagesContainer) {
+        countdownImagesContainer.classList.remove('fade-out');
+        countdownImagesContainer.classList.add('is-active');
+      }
+
       // Prime video playback within a user gesture so it can later play with sound
       video.muted = true;
       const prime = video.play();
@@ -53,6 +99,25 @@ document.addEventListener('DOMContentLoaded', () => {
       preCountdown.style.fontSize = `${(11 - n) * (11 - n) * base}rem`;
       playBeat();
 
+      let hitIndex = 0;
+      const revealNextImage = (delay = 0) => {
+        if (!countdownImagesContainer) return;
+        if (hitIndex >= countdownFrames.length) return;
+        const frame = countdownFrames[hitIndex];
+        const progress = countdownFrames.length > 1 ? hitIndex / (countdownFrames.length - 1) : 1;
+        const duration = Math.max(0.24, 0.88 - progress * 0.46);
+        frame.style.setProperty('--hit-duration', `${duration.toFixed(2)}s`);
+        const activate = () => frame.classList.add('active');
+        if (delay) {
+          setTimeout(() => requestAnimationFrame(activate), delay);
+        } else {
+          requestAnimationFrame(activate);
+        }
+        hitIndex += 1;
+      };
+
+      revealNextImage();
+
       // Enable transition after initial size is applied so first number doesn't animate
       requestAnimationFrame(() => {
         preCountdown.style.transition = 'font-size 0.7s var(--ease-med)';
@@ -63,10 +128,25 @@ document.addEventListener('DOMContentLoaded', () => {
         preCountdown.textContent = n;
         preCountdown.style.fontSize = `${(11 - n) * (11 - n) * base}rem`;
         playBeat();
+        revealNextImage();
+        if (n <= 4) {
+          revealNextImage(240 - (n * 30));
+        }
+        if (n <= 2) {
+          revealNextImage(160);
+        }
         if (n <= 1) {
           clearInterval(timer);
           setTimeout(() => {
             preCountdown.classList.add('hidden');
+            if (countdownImagesContainer) {
+              countdownImagesContainer.classList.remove('is-active');
+              countdownImagesContainer.classList.add('fade-out');
+              setTimeout(() => {
+                countdownImagesContainer.classList.remove('fade-out');
+                countdownFrames.forEach((frame) => frame.classList.remove('active'));
+              }, 1200);
+            }
             video.muted = false;
             video.volume = 1.0;
             video.play();

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <body class="no-scroll">
   <div id="preCountdown" class="countdown-overlay"></div>
   <div class="background-video">
+    <div class="countdown-image-stack" id="countdownImages"></div>
     <video playsinline muted preload="auto" poster="assets/video-fallback.jpg">
       <source src="assets/video.mp4" type="video/mp4">
       <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">


### PR DESCRIPTION
## Summary
- add a countdown photo stack above the video to stage the reveal animation
- style the stacked portraits with dramatic fly-in animations that accelerate as the countdown nears one
- drive the image sequencing from the tap-to-start countdown, including extra hits near the finale and a fade-out into the video

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccb70d44a8832ea0c6dd232fdb86fc