### PR TITLE
Refine countdown framing and reveal

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -62,6 +62,17 @@ html, body {
 .countdown-image-stack.is-active::after {
   opacity: 1;
 }
+.countdown-image-stack.countdown-grid {
+  --frame-min: clamp(70px, 16vw, 180px);
+  --frame-max: min(20vw, 200px);
+  --frame-gap: clamp(8px, 2vw, 24px);
+  display: grid;
+  place-content: center;
+  grid-template-columns: repeat(5, minmax(var(--frame-min), var(--frame-max)));
+  grid-auto-rows: minmax(var(--frame-min), var(--frame-max));
+  gap: var(--frame-gap);
+  padding: clamp(12px, 4vw, 36px);
+}
 .background-video video {
   position: absolute;
   inset: 0;
@@ -117,6 +128,50 @@ html.js .background-video video.is-visible {
 .countdown-image.active img {
   animation: countdownHit var(--hit-duration, 0.6s) cubic-bezier(0.36, 0, 0.07, 1.03) forwards;
 }
+.countdown-image-stack.countdown-grid .countdown-image {
+  position: relative;
+  top: auto;
+  left: auto;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transform: scale(0.86);
+  filter: drop-shadow(0 18px 40px rgba(0,0,0,0.32));
+  border-radius: 22px;
+  overflow: hidden;
+  transition: opacity 0.42s ease, transform 0.52s var(--ease-med);
+}
+.countdown-image-stack.countdown-grid .countdown-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(0,0,0,0.18);
+  opacity: 0;
+  transition: opacity 0.42s ease;
+  z-index: 1;
+}
+.countdown-image-stack.countdown-grid .countdown-image img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  transform: scale(1.12) rotate(var(--tilt-start, 0deg));
+  opacity: 0;
+  z-index: 0;
+}
+.countdown-image-stack.countdown-grid .countdown-image.active {
+  opacity: 1;
+  transform: scale(1);
+}
+.countdown-image-stack.countdown-grid .countdown-image.active::before {
+  opacity: 1;
+}
+.countdown-image-stack.countdown-grid .countdown-image.active img {
+  animation: countdownFrameReveal var(--hit-duration, 0.6s) cubic-bezier(0.36, 0, 0.2, 1) forwards;
+}
 .countdown-image-stack.fade-out {
   opacity: 0;
   transition: opacity 0.7s ease;
@@ -132,6 +187,16 @@ html.js .background-video video.is-visible {
 }
 .countdown-image-stack.fade-out::after {
   opacity: 0;
+}
+.countdown-image-stack.countdown-grid.show-video {
+  pointer-events: none;
+  animation: frameGlow 1.1s ease forwards;
+}
+.countdown-image-stack.countdown-grid.show-video::after {
+  opacity: 0.2;
+}
+.countdown-image-stack.countdown-grid.show-video .countdown-image::before {
+  background: rgba(0,0,0,0.22);
 }
 
 @keyframes countdownHit {
@@ -150,6 +215,34 @@ html.js .background-video video.is-visible {
   100% {
     opacity: 1;
     transform: translate(0, 0) scale(1) rotate(0deg);
+  }
+}
+
+@keyframes countdownFrameReveal {
+  0% {
+    opacity: 0;
+    transform: scale(1.16) rotate(var(--tilt-start, 0deg));
+  }
+  30% {
+    opacity: 1;
+    transform: scale(0.92) rotate(var(--tilt-start, 0deg));
+  }
+  64% {
+    opacity: 1;
+    transform: scale(1.04) rotate(var(--tilt-mid, 0deg));
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes frameGlow {
+  from {
+    filter: brightness(0.92);
+  }
+  to {
+    filter: brightness(1);
   }
 }
 
@@ -173,10 +266,36 @@ html.js .background-video video.is-visible {
   font-family: var(--font-heading);
   font-size: 5rem;
   transition: opacity var(--t-med) var(--ease-med);
+  overflow: hidden;
 }
 
 .countdown-overlay.start-prompt {
   cursor: pointer;
+}
+
+.countdown-overlay::before {
+  content: '';
+  position: absolute;
+  width: clamp(140px, 32vw, 360px);
+  height: clamp(140px, 32vw, 360px);
+  border-radius: 22px;
+  background: rgba(0,0,0,0.38);
+  border: 2px solid rgba(255,255,255,0.35);
+  box-shadow: 0 24px 40px rgba(0,0,0,0.48);
+  opacity: 0;
+  transform: scale(0.86);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  z-index: 0;
+}
+
+.countdown-overlay.is-counting {
+  background: transparent;
+  pointer-events: none;
+}
+
+.countdown-overlay.is-counting::before {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .countdown-overlay.hidden {

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -22,15 +22,38 @@ document.addEventListener('DOMContentLoaded', () => {
     'assets/images/AUG5329_bw.jpg'
   ];
   const countdownFrames = [];
+  const squareLayout = [
+    { row: 1, col: 1 },
+    { row: 1, col: 2 },
+    { row: 1, col: 3 },
+    { row: 1, col: 4 },
+    { row: 1, col: 5 },
+    { row: 2, col: 5 },
+    { row: 3, col: 5 },
+    { row: 4, col: 5 },
+    { row: 5, col: 5 },
+    { row: 5, col: 4 },
+    { row: 5, col: 3 },
+    { row: 5, col: 2 },
+    { row: 5, col: 1 },
+    { row: 4, col: 1 },
+    { row: 3, col: 1 },
+    { row: 2, col: 1 }
+  ];
   const randomBetween = (min, max) => Math.random() * (max - min) + min;
 
   if (countdownImagesContainer) {
-    countdownImageSources.forEach((src) => {
+    countdownImagesContainer.classList.add('countdown-grid');
+    const framesToUse = countdownImageSources.slice(0, squareLayout.length);
+    framesToUse.forEach((src, index) => {
       const frame = document.createElement('div');
       frame.className = 'countdown-image';
-      frame.style.setProperty('--tx', `${randomBetween(-38, 38).toFixed(2)}px`);
-      frame.style.setProperty('--ty', `${randomBetween(-48, 48).toFixed(2)}px`);
-      const tilt = randomBetween(-7, 7);
+      const layout = squareLayout[index];
+      if (layout) {
+        frame.style.gridRow = layout.row;
+        frame.style.gridColumn = layout.col;
+      }
+      const tilt = randomBetween(-5, 5);
       frame.style.setProperty('--tilt-start', `${tilt.toFixed(2)}deg`);
       frame.style.setProperty('--tilt-mid', `${(tilt * 0.35).toFixed(2)}deg`);
       const img = document.createElement('img');
@@ -73,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const start = () => {
       audioCtx.resume();
       preCountdown.classList.remove('start-prompt');
+      preCountdown.classList.add('is-counting');
       preCountdown.removeEventListener('click', start);
 
       if (countdownImagesContainer) {
@@ -140,15 +164,11 @@ document.addEventListener('DOMContentLoaded', () => {
           setTimeout(() => {
             preCountdown.classList.add('hidden');
             if (countdownImagesContainer) {
-              countdownImagesContainer.classList.remove('is-active');
-              countdownImagesContainer.classList.add('fade-out');
-              setTimeout(() => {
-                countdownImagesContainer.classList.remove('fade-out');
-                countdownFrames.forEach((frame) => frame.classList.remove('active'));
-              }, 1200);
+              countdownImagesContainer.classList.add('show-video');
             }
             video.muted = false;
             video.volume = 1.0;
+            video.classList.add('is-visible');
             video.play();
           }, 500);
         }


### PR DESCRIPTION
## Summary
- arrange countdown photo frames into a centered grid that builds a square around the timer
- reveal a new frame with every count, accelerating additional reveals near the end and keep the collage visible as the video plays
- restyle the overlay so the countdown number sits inside the photo square and the video is exposed once the countdown finishes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cccf9bfd1c832e83ca8929bf4e5790