### PR TITLE
Create centered countdown container with framed imagery

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -37,166 +37,158 @@ html, body {
   box-sizing: border-box;
 }
 
-.background-video {
-  position: fixed;
-  inset: 0;
-  background: url('../video-fallback.jpg') center/cover no-repeat;
-  overflow: hidden;
-  z-index: 0;
+.countdown-stage {
+  --shell-width: min(78vw, 640px);
+  --shell-height: calc(var(--shell-width) * 0.5625);
+  --stack-scale: 1.4;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: clamp(32px, 8vw, 140px);
 }
-.background-video .countdown-image-stack {
+
+.countdown-shell {
+  position: relative;
+  width: var(--shell-width);
+  max-width: 640px;
+  aspect-ratio: 16 / 9;
+  border-radius: clamp(18px, 3vw, 28px);
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255,255,255,0.28);
+  box-shadow: 0 32px 60px rgba(0,0,0,0.36);
+  z-index: 2;
+}
+
+.countdown-video {
   position: absolute;
   inset: 0;
+  background: #000;
+  opacity: 0;
+  transition: opacity var(--t-med) var(--ease-med);
+}
+
+.countdown-video video {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.countdown-display {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 48px);
+  transition: opacity 0.6s ease;
+  background: radial-gradient(circle at 50% 50%, rgba(0,0,0,0.32), rgba(0,0,0,0.58));
+}
+
+.countdown-shell.show-video .countdown-display {
+  opacity: 0;
   pointer-events: none;
-  overflow: hidden;
+}
+
+.countdown-shell.show-video .countdown-video {
+  opacity: 1;
+}
+
+#countdownDemo {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  color: var(--white);
+  line-height: 1;
+  text-align: center;
+  text-shadow: 0 22px 32px rgba(0,0,0,0.35);
+}
+
+.countdown-stage .countdown-image-stack {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(calc(var(--shell-width) * var(--stack-scale)), 92vmin);
+  height: min(calc(var(--shell-width) * var(--stack-scale)), 92vmin);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
   z-index: 1;
 }
+
 .countdown-image-stack::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(0,0,0,0.38) 0%, rgba(0,0,0,0.18) 55%, rgba(0,0,0,0.42) 100%);
+  border-radius: clamp(24px, 4vw, 32px);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
   opacity: 0;
   transition: opacity 0.6s ease;
 }
+
 .countdown-image-stack.is-active::after {
   opacity: 1;
 }
-.countdown-image-stack.countdown-grid {
-  --frame-min: clamp(70px, 16vw, 180px);
-  --frame-max: min(20vw, 200px);
-  --frame-gap: clamp(8px, 2vw, 24px);
-  display: grid;
-  place-content: center;
-  grid-template-columns: repeat(5, minmax(var(--frame-min), var(--frame-max)));
-  grid-auto-rows: minmax(var(--frame-min), var(--frame-max));
-  gap: var(--frame-gap);
-  padding: clamp(12px, 4vw, 36px);
-}
-.background-video video {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: opacity var(--t-med) var(--ease-med);
-}
-html.js .background-video video {
-  opacity: 0;
-}
-html.js .background-video video.is-visible {
-  opacity: 1;
-}
+
 .countdown-image {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: clamp(220px, 58vw, 540px);
-  transform: translate(-50%, -50%);
+  top: calc(var(--pos-y, 50) * 1%);
+  left: calc(var(--pos-x, 50) * 1%);
+  width: clamp(104px, 14vw, 180px);
+  border-radius: clamp(18px, 3vw, 26px);
+  overflow: hidden;
+  box-shadow: 0 26px 48px rgba(0,0,0,0.38);
+  transform: translate(-50%, -50%) scale(0.8);
   opacity: 0;
-  filter: drop-shadow(0 24px 50px rgba(0,0,0,0.38));
-  transform-origin: center;
-  will-change: transform, opacity;
-  transition: opacity 0.4s ease;
+  transition: opacity 0.45s ease, transform 0.52s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
-.countdown-image.active {
-  opacity: 1;
-}
+
 .countdown-image::before {
   content: '';
   position: absolute;
   inset: 0;
-  border-radius: 28px;
-  background: rgba(0,0,0,0.18);
-  filter: blur(25px);
+  background: rgba(0,0,0,0.2);
   opacity: 0;
-  transform: translate3d(0,0,-1px);
-  transition: opacity 0.4s ease;
+  transition: opacity 0.45s ease;
+  z-index: 1;
 }
+
 .countdown-image img {
   display: block;
   width: 100%;
-  height: auto;
-  border-radius: 28px;
+  height: 100%;
   object-fit: cover;
-  transform: translate(calc(var(--tx, 0px)), calc(var(--ty, 0px))) scale(1.22) rotate(var(--tilt-start, 0deg));
+  transform: scale(1.1) rotate(var(--tilt-start, 0deg));
   opacity: 0;
 }
+
+.countdown-image.active {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
 .countdown-image.active::before {
   opacity: 1;
 }
+
 .countdown-image.active img {
-  animation: countdownHit var(--hit-duration, 0.6s) cubic-bezier(0.36, 0, 0.07, 1.03) forwards;
-}
-.countdown-image-stack.countdown-grid .countdown-image {
-  position: relative;
-  top: auto;
-  left: auto;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transform: scale(0.86);
-  filter: drop-shadow(0 18px 40px rgba(0,0,0,0.32));
-  border-radius: 22px;
-  overflow: hidden;
-  transition: opacity 0.42s ease, transform 0.52s var(--ease-med);
-}
-.countdown-image-stack.countdown-grid .countdown-image::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: rgba(0,0,0,0.18);
-  opacity: 0;
-  transition: opacity 0.42s ease;
-  z-index: 1;
-}
-.countdown-image-stack.countdown-grid .countdown-image img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: inherit;
-  transform: scale(1.12) rotate(var(--tilt-start, 0deg));
-  opacity: 0;
-  z-index: 0;
-}
-.countdown-image-stack.countdown-grid .countdown-image.active {
-  opacity: 1;
-  transform: scale(1);
-}
-.countdown-image-stack.countdown-grid .countdown-image.active::before {
-  opacity: 1;
-}
-.countdown-image-stack.countdown-grid .countdown-image.active img {
   animation: countdownFrameReveal var(--hit-duration, 0.6s) cubic-bezier(0.36, 0, 0.2, 1) forwards;
 }
+
 .countdown-image-stack.fade-out {
   opacity: 0;
   transition: opacity 0.7s ease;
-  pointer-events: none;
 }
+
 .countdown-image-stack.fade-out .countdown-image {
   opacity: 0;
-  transition: opacity 0.8s ease, transform 0.9s ease;
   transform: translate(-50%, -50%) scale(1.05);
+  transition: opacity 0.45s ease, transform 0.6s ease;
 }
-.countdown-image-stack.fade-out .countdown-image::before {
-  opacity: 0;
-}
+
 .countdown-image-stack.fade-out::after {
   opacity: 0;
-}
-.countdown-image-stack.countdown-grid.show-video {
-  pointer-events: none;
-  animation: frameGlow 1.1s ease forwards;
-}
-.countdown-image-stack.countdown-grid.show-video::after {
-  opacity: 0.2;
-}
-.countdown-image-stack.countdown-grid.show-video .countdown-image::before {
-  background: rgba(0,0,0,0.22);
 }
 
 @keyframes countdownHit {

--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -4,23 +4,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const el = document.getElementById('countdownDemo');
   if (!el) return;
 
-  const background = document.querySelector('.background-video');
-  const video = background?.querySelector('video');
+  const stage = document.querySelector('.countdown-stage');
+  const shell = document.querySelector('.countdown-shell');
+  const video = shell?.querySelector('video');
 
   const countdownImageData = [
-    { src: 'assets/images/AUG4710_bw.jpg', tx: -34, ty: -22, tiltStart: '-6deg', tiltMid: '-2deg' },
-    { src: 'assets/images/AUG4726_bw.jpg', tx: 24, ty: -18, tiltStart: '7deg', tiltMid: '2deg' },
-    { src: 'assets/images/AUG4738_bw.jpg', tx: -18, ty: 28, tiltStart: '-4deg', tiltMid: '-1deg' },
-    { src: 'assets/images/AUG4759_bw.jpg', tx: 26, ty: 20, tiltStart: '5deg', tiltMid: '1deg' },
-    { src: 'assets/images/AUG4761_bw.jpg', tx: -22, ty: -30, tiltStart: '-5deg', tiltMid: '-2deg' },
-    { src: 'assets/images/AUG4849_bw.jpg', tx: 34, ty: 18, tiltStart: '6deg', tiltMid: '2deg' },
-    { src: 'assets/images/AUG4869_bw.jpg', tx: -16, ty: 26, tiltStart: '-3deg', tiltMid: '-1deg' },
-    { src: 'assets/images/AUG5106_bw.jpg', tx: 20, ty: -26, tiltStart: '4deg', tiltMid: '1deg' },
-    { src: 'assets/images/AUG5127_bw.jpg', tx: -28, ty: 16, tiltStart: '-6deg', tiltMid: '-2deg' },
-    { src: 'assets/images/AUG5139_bw.jpg', tx: 16, ty: 24, tiltStart: '5deg', tiltMid: '1deg' }
+    { src: 'assets/images/AUG4710_bw.jpg', x: 10, y: 10, tiltStart: '-6deg', tiltMid: '-2deg' },
+    { src: 'assets/images/AUG4726_bw.jpg', x: 30, y: 8, tiltStart: '5deg', tiltMid: '1deg' },
+    { src: 'assets/images/AUG4738_bw.jpg', x: 50, y: 6, tiltStart: '-4deg', tiltMid: '-1deg' },
+    { src: 'assets/images/AUG4759_bw.jpg', x: 70, y: 8, tiltStart: '3deg', tiltMid: '1deg' },
+    { src: 'assets/images/AUG4761_bw.jpg', x: 90, y: 10, tiltStart: '-5deg', tiltMid: '-2deg' },
+    { src: 'assets/images/AUG4849_bw.jpg', x: 92, y: 35, tiltStart: '6deg', tiltMid: '2deg' },
+    { src: 'assets/images/AUG4869_bw.jpg', x: 88, y: 88, tiltStart: '-3deg', tiltMid: '-1deg' },
+    { src: 'assets/images/AUG5106_bw.jpg', x: 50, y: 92, tiltStart: '4deg', tiltMid: '1deg' },
+    { src: 'assets/images/AUG5127_bw.jpg', x: 10, y: 90, tiltStart: '-6deg', tiltMid: '-2deg' },
+    { src: 'assets/images/AUG5139_bw.jpg', x: 8, y: 50, tiltStart: '5deg', tiltMid: '1deg' }
   ];
 
-  const imageStack = background ? document.createElement('div') : null;
+  const imageStack = stage ? document.createElement('div') : null;
   let imageElements = [];
   if (imageStack && countdownImageData.length) {
     imageStack.className = 'countdown-image-stack';
@@ -30,8 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
     imageElements = sequence.map((data) => {
       const wrapper = document.createElement('figure');
       wrapper.className = 'countdown-image';
-      if (typeof data.tx === 'number') wrapper.style.setProperty('--tx', `${data.tx}px`);
-      if (typeof data.ty === 'number') wrapper.style.setProperty('--ty', `${data.ty}px`);
+      if (typeof data.x === 'number') wrapper.style.setProperty('--pos-x', `${data.x}`);
+      if (typeof data.y === 'number') wrapper.style.setProperty('--pos-y', `${data.y}`);
       if (data.tiltStart) wrapper.style.setProperty('--tilt-start', data.tiltStart);
       if (data.tiltMid) wrapper.style.setProperty('--tilt-mid', data.tiltMid);
 
@@ -46,10 +47,10 @@ document.addEventListener('DOMContentLoaded', () => {
       return wrapper;
     });
 
-    if (video && video.parentNode) {
-      video.parentNode.insertBefore(imageStack, video);
-    } else if (background) {
-      background.appendChild(imageStack);
+    if (stage && shell && shell.parentNode === stage) {
+      stage.insertBefore(imageStack, shell);
+    } else if (stage) {
+      stage.appendChild(imageStack);
     }
 
     requestAnimationFrame(() => {
@@ -76,7 +77,15 @@ document.addEventListener('DOMContentLoaded', () => {
     osc.stop(now + 0.3);
   };
 
-  const sizeFor = (val) => `${(11 - val) * (11 - val) * 0.5}rem`;
+  const containerRect = shell?.getBoundingClientRect();
+  const fallbackMeasure = Math.min(window.innerWidth, window.innerHeight) * 0.5;
+  const minSize = containerRect ? Math.min(containerRect.width, containerRect.height) * 0.32 : fallbackMeasure * 0.6;
+  const maxSize = containerRect ? Math.min(containerRect.width, containerRect.height) * 0.72 : fallbackMeasure;
+  const sizeFor = (val) => {
+    const progress = (10 - val) / 9;
+    const nextSize = minSize + (maxSize - minSize) * Math.max(0, Math.min(1, progress));
+    return `${Math.max(48, Math.min(nextSize, maxSize))}px`;
+  };
 
   el.textContent = n;
   el.style.fontFamily = 'var(--font-heading)';
@@ -84,7 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const totalImages = imageElements.length;
   let currentImage = -1;
-  let activeImage = null;
   const baseDuration = 0.72;
   const minDuration = 0.32;
   const durationStep = totalImages > 1 ? (baseDuration - minDuration) / (totalImages - 1) : 0;
@@ -92,15 +100,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const showNextImage = () => {
     if (!imageElements.length) return;
     const nextIndex = Math.min(currentImage + 1, imageElements.length - 1);
-    if (nextIndex === currentImage && activeImage) return;
+    if (nextIndex === currentImage) return;
     const nextEl = imageElements[nextIndex];
     const duration = Math.max(minDuration, baseDuration - durationStep * nextIndex);
     nextEl.style.setProperty('--hit-duration', `${duration}s`);
-    if (activeImage && activeImage !== nextEl) {
-      activeImage.classList.remove('active');
-    }
     nextEl.classList.add('active');
-    activeImage = nextEl;
     currentImage = nextIndex;
   };
 
@@ -160,9 +164,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   Promise.all([countdownComplete, videoReady]).then(() => {
     el.style.opacity = '0';
-    const intro = el.closest('.intro-card-container');
-    if (intro) {
-      intro.classList.remove('visible');
+    if (shell) {
+      shell.classList.add('show-video');
     }
     if (imageStack) {
       imageStack.classList.add('fade-out');
@@ -173,7 +176,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }, { once: true });
     }
     if (video) {
-      video.classList.add('is-visible');
       if (video.paused && typeof video.play === 'function') {
         video.play().catch(() => {});
       }

--- a/countdown.html
+++ b/countdown.html
@@ -14,15 +14,18 @@
   <link rel="stylesheet" href="assets/css/save-the-date.css" />
 </head>
 <body class="no-scroll">
-  <div class="background-video">
-    <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
-      <source src="assets/video.mp4" type="video/mp4" />
-      <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
-    </video>
-  </div>
-  <div class="video-overlay"></div>
-  <div class="intro-card-container visible">
-    <div id="countdownDemo"></div>
+  <div class="countdown-stage">
+    <div class="countdown-shell">
+      <div class="countdown-video">
+        <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
+          <source src="assets/video.mp4" type="video/mp4" />
+          <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
+        </video>
+      </div>
+      <div class="countdown-display">
+        <div id="countdownDemo"></div>
+      </div>
+    </div>
   </div>
   <script src="assets/js/countdown-demo.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- wrap the countdown and video inside a fixed aspect ratio shell centered on the screen so the media stays contained
- restyle the supporting imagery to ring the shell and remain within the viewport while fading out for video playback
- update the countdown script to position images along the square border, accumulate them through the countdown, and reveal the video inside the shell

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccd270527c832e8d63c02c89f0d720