### PR TITLE
Create centered gallery layout

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -29,6 +29,101 @@ html, body {
   color: var(--white);
 }
 
+.gallery-stage {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(32px, 7vw, 120px);
+  background: radial-gradient(circle at top left, rgba(0, 87, 60, 0.32), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(0, 87, 60, 0.28), transparent 50%),
+              var(--bg-emerald-dark);
+}
+
+.gallery-frame {
+  position: relative;
+  width: min(1100px, 100%);
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+  gap: clamp(14px, 3vw, 40px);
+}
+
+.photo-grid {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+  gap: inherit;
+  pointer-events: none;
+}
+
+.photo-grid::after {
+  content: '';
+  grid-column: 3;
+  grid-row: 3;
+  background: rgba(255,255,255,0.04);
+  border-radius: clamp(26px, 3.2vw, 40px);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.1);
+  pointer-events: none;
+}
+
+.photo-grid .countdown-image {
+  position: relative;
+  opacity: 1;
+  transform: none;
+  border-radius: clamp(20px, 3vw, 32px);
+  overflow: hidden;
+  box-shadow: 0 26px 46px rgba(0,0,0,0.35);
+  background: rgba(255,255,255,0.05);
+}
+
+.photo-grid .countdown-image.active {
+  transform: none;
+}
+
+.photo-grid .countdown-image::before {
+  display: none;
+}
+
+.photo-grid .countdown-image img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  transform: none;
+  opacity: 1;
+}
+
+.photo-grid .countdown-image.active img {
+  animation: none;
+}
+
+.intro-card-container {
+  grid-column: 2 / span 3;
+  grid-row: 2 / span 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.intro-card-shell {
+  width: 100%;
+  height: 100%;
+  background: var(--white);
+  color: var(--bg-emerald-dark);
+  border-radius: clamp(28px, 4vw, 46px);
+  padding: clamp(28px, 5vw, 64px);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.28);
+  border: 2px solid rgba(255, 255, 255, 0.28);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: clamp(320px, 60vw, 540px);
+}
+
 .no-scroll {
   overflow: hidden;
 }
@@ -338,33 +433,29 @@ html, body {
 }
 
 .intro-card-container {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2;
-  opacity: 0;
-  transition: opacity var(--t-med) var(--ease-med);
-  pointer-events: none;
+  position: relative;
+  z-index: 1;
+  opacity: 1;
 }
+
 .intro-card-container.visible {
   opacity: 1;
-  pointer-events: auto;
 }
 
 .intro-card-container .flip-card {
-  transform: scale(0) rotate(-360deg);
+  transform: none;
 }
 
 .intro-card-container.visible .flip-card {
-  animation: spinIn var(--t-med) var(--ease-med) forwards;
+  animation: none;
 }
 
 .flip-card {
   background: transparent;
-  width: 340px;
-  height: 380px;
+  width: 100%;
+  max-width: 360px;
+  height: auto;
+  min-height: clamp(280px, 52vw, 500px);
   perspective: 1000px;
 }
 .flip-inner {

--- a/index.html
+++ b/index.html
@@ -12,47 +12,42 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"></noscript>
   <link rel="stylesheet" href="assets/css/save-the-date.css">
 </head>
-<body class="no-scroll">
-  <div id="preCountdown" class="countdown-overlay"></div>
-  <div class="background-video">
-    <div class="countdown-image-stack" id="countdownImages"></div>
-    <video playsinline muted preload="auto" poster="assets/video-fallback.jpg">
-      <source src="assets/video.mp4" type="video/mp4">
-      <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
-    </video>
-  </div>
-  <div class="video-overlay"></div>
-
-  <div class="intro-card-container" id="introCard">
-    <div class="flip-card">
-      <div class="flip-inner">
-        <div class="flip-front">
-          <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
-          <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
-          <div id="countdown"></div>
-        </div>
-        <div class="flip-back">
-          <div id="backContent">
-            <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p><br>
-            <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
-          </div>
-          <div id="cantAttendFormContainer" class="card-form-container" style="display:none;">
-            <form action="https://script.google.com/macros/s/AKfycbw1oW3-NLd95psh53-YJFoUoa80b1jeyw9oEXX0TWffxMEyauwYvn6aVOn0UjdZgZF2IQ/exec" method="post">
-              <label>
-                Name: <input type="text" name="name" required>
-              </label><br>
-              <label>
-                Email: <input type="email" name="email" required>
-              </label><br><br>
-              <button type="submit">Send</button>
-            </form>
+<body>
+  <main class="gallery-stage">
+    <div class="gallery-frame">
+      <div class="photo-grid" id="countdownImages"></div>
+      <div class="intro-card-container visible" id="introCard">
+        <div class="intro-card-shell">
+          <div class="flip-card">
+            <div class="flip-inner">
+              <div class="flip-front">
+                <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
+                <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
+                <div id="countdown"></div>
+              </div>
+              <div class="flip-back">
+                <div id="backContent">
+                  <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p><br>
+                  <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
+                </div>
+                <div id="cantAttendFormContainer" class="card-form-container" style="display:none;">
+                  <form action="https://script.google.com/macros/s/AKfycbw1oW3-NLd95psh53-YJFoUoa80b1jeyw9oEXX0TWffxMEyauwYvn6aVOn0UJdZgZF2IQ/exec" method="post">
+                    <label>
+                      Name: <input type="text" name="name" required>
+                    </label><br>
+                    <label>
+                      Email: <input type="email" name="email" required>
+                    </label><br><br>
+                    <button type="submit">Send</button>
+                  </form>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-
-
+  </main>
   <div id="thankYouMessage" class="thank-you-container" style="display:none;">
     <div class="thank-you-card">
       <p>Thank you for submitting and we are sorry you will not be able to attend the wedding. We will email you the wedding site once it is available so you can still engage and be a part of the celebration.</p>


### PR DESCRIPTION
## Summary
- wrap the save-the-date landing page content in a centered gallery stage with a large white container that hosts the flip card and countdown
- add supporting gallery layout styles so the surrounding photo grid and flip card sizing sit cleanly within the new container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccdcf117ac832e953869d027af6da3