### PR TITLE
Center photo gallery within frame

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -50,6 +50,10 @@ html, body {
   grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-template-rows: repeat(5, minmax(0, 1fr));
   gap: clamp(14px, 3vw, 40px);
+  padding: clamp(20px, 4vw, 60px);
+  box-sizing: border-box;
+  justify-content: center;
+  align-content: center;
 }
 
 .photo-grid {
@@ -60,6 +64,8 @@ html, body {
   grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-template-rows: repeat(5, minmax(0, 1fr));
   gap: inherit;
+  justify-content: center;
+  align-content: center;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- add interior padding to the gallery frame to give the image grid even breathing room
- center the photo grid tracks within the padded frame for a balanced layout

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68cce4c4ef78832e886f3ae13dd09567