### PR TITLE
Add flip-card border gallery variant

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -1,0 +1,306 @@
+:root {
+  --emerald-dark: #03281c;
+  --emerald-mid: #0c3f2b;
+  --cream: #f5f1eb;
+  --text-dark: #0c2c1d;
+  --text-muted: rgba(12, 44, 29, 0.72);
+  --accent: #ffe3a2;
+  --card-radius: clamp(24px, 4vw, 40px);
+  --transition: 0.35s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: 'Spectral', serif;
+  background: radial-gradient(circle at top left, rgba(12, 63, 43, 0.38), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(12, 63, 43, 0.28), transparent 60%),
+              var(--emerald-dark);
+  color: var(--text-dark);
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  min-height: 100vh;
+}
+
+.page-border {
+  display: grid;
+  grid-template-columns: minmax(110px, 18vw) minmax(110px, 18vw) 1fr minmax(110px, 18vw);
+  grid-template-rows: minmax(110px, 18vh) minmax(110px, 18vh) 1fr minmax(110px, 18vh);
+  grid-template-areas:
+    "top-left top-left-center top-right-center top-right"
+    "mid-left-upper content content mid-right-upper"
+    "mid-left-lower content content mid-right-lower"
+    "bottom-left bottom-left-center bottom-right-center bottom-right";
+  width: 100%;
+  min-height: 100vh;
+  overflow: hidden;
+  gap: clamp(12px, 3vw, 26px);
+  padding: clamp(20px, 4vw, 48px);
+}
+
+.border-cell {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: clamp(16px, 3vw, 28px);
+}
+
+.border-cell::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, transparent 45%, rgba(2, 24, 16, 0.45));
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.border-cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform: scale(1.05);
+  transition: transform var(--transition), filter var(--transition);
+  filter: saturate(0.78) contrast(1.05);
+}
+
+.border-cell:hover img {
+  transform: scale(1.12);
+  filter: saturate(1) contrast(1.12);
+}
+
+.top-left {
+  grid-area: top-left;
+}
+
+.top-left-center {
+  grid-area: top-left-center;
+}
+
+.top-right-center {
+  grid-area: top-right-center;
+}
+
+.top-right {
+  grid-area: top-right;
+}
+
+.mid-left-upper {
+  grid-area: mid-left-upper;
+}
+
+.mid-left-lower {
+  grid-area: mid-left-lower;
+}
+
+.mid-right-upper {
+  grid-area: mid-right-upper;
+}
+
+.mid-right-lower {
+  grid-area: mid-right-lower;
+}
+
+.bottom-left {
+  grid-area: bottom-left;
+}
+
+.bottom-left-center {
+  grid-area: bottom-left-center;
+}
+
+.bottom-right-center {
+  grid-area: bottom-right-center;
+}
+
+.bottom-right {
+  grid-area: bottom-right;
+}
+
+.content-card {
+  grid-area: content;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-shell {
+  position: relative;
+  background: linear-gradient(145deg, rgba(245, 241, 235, 0.96), rgba(245, 241, 235, 0.88));
+  border-radius: var(--card-radius);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.35);
+  padding: clamp(24px, 4vw, 48px);
+  border: 1px solid rgba(12, 44, 29, 0.12);
+  width: min(460px, 100%);
+  min-height: clamp(320px, 60vw, 520px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-shell::before {
+  content: '';
+  position: absolute;
+  inset: clamp(12px, 2vw, 26px);
+  border-radius: inherit;
+  border: 1px dashed rgba(12, 44, 29, 0.16);
+  pointer-events: none;
+}
+
+.flip-card {
+  width: 100%;
+  height: 100%;
+  perspective: 1200px;
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s ease;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped .flip-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-face {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: clamp(18px, 3vw, 30px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+  border: 1.5px solid rgba(12, 44, 29, 0.12);
+  padding: clamp(24px, 4vw, 44px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  backface-visibility: hidden;
+}
+
+.flip-front {
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.flip-back {
+  background: rgba(255, 255, 255, 0.92);
+  transform: rotateY(180deg);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: clamp(0.7rem, 1.4vw, 0.9rem);
+  color: var(--text-muted);
+  margin-bottom: clamp(10px, 1.4vw, 16px);
+}
+
+.wedding-names {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: clamp(2.4rem, 5vw, 3.6rem);
+  letter-spacing: 0.06em;
+  margin: 0 0 clamp(12px, 2vw, 20px);
+  color: var(--text-dark);
+}
+
+.date {
+  font-size: clamp(1rem, 2vw, 1.3rem);
+  color: var(--text-muted);
+  margin-bottom: clamp(18px, 2vw, 28px);
+}
+
+.description,
+.travel-note {
+  margin: 0 0 clamp(18px, 3vw, 28px);
+  line-height: 1.6;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+}
+
+.flip-back h2 {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  margin-bottom: clamp(14px, 2vw, 22px);
+  color: var(--text-dark);
+}
+
+.flip-back ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 clamp(18px, 3vw, 26px);
+  width: 100%;
+  color: var(--text-dark);
+  text-align: left;
+  line-height: 1.5;
+}
+
+.flip-back li + li {
+  margin-top: clamp(10px, 2vw, 16px);
+}
+
+.flip-action {
+  border: none;
+  background: var(--text-dark);
+  color: var(--cream);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: clamp(12px, 2.5vw, 16px) clamp(22px, 5vw, 30px);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.flip-action:hover,
+.flip-action:focus-visible {
+  background: var(--accent);
+  color: var(--text-dark);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 960px) {
+  .page-border {
+    grid-template-columns: minmax(90px, 22vw) minmax(90px, 22vw) 1fr minmax(90px, 22vw);
+    grid-template-rows: minmax(90px, 22vh) minmax(90px, 22vh) 1fr minmax(90px, 22vh);
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    align-items: flex-start;
+  }
+
+  .page-border {
+    grid-template-columns: minmax(70px, 25vw) minmax(70px, 25vw) 1fr minmax(70px, 25vw);
+    grid-template-rows: minmax(70px, 24vh) minmax(70px, 24vh) 1fr minmax(70px, 24vh);
+    padding: clamp(16px, 5vw, 32px);
+    gap: clamp(10px, 4vw, 22px);
+  }
+
+  .card-shell {
+    padding: clamp(18px, 6vw, 32px);
+  }
+}
+
+@media (max-width: 520px) {
+  .page-border {
+    grid-template-columns: minmax(56px, 28vw) minmax(56px, 28vw) 1fr minmax(56px, 28vw);
+    grid-template-rows: minmax(56px, 26vh) minmax(56px, 26vh) 1fr minmax(56px, 26vh);
+  }
+
+  .card-shell::before {
+    inset: clamp(10px, 3vw, 18px);
+  }
+}

--- a/border-flip.html
+++ b/border-flip.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Framed Memories Flip</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/bordered-gallery-flip.css">
+</head>
+<body>
+  <div class="page-border">
+    <div class="border-cell top-left"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
+    <div class="border-cell top-left-center"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
+    <div class="border-cell top-right-center"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
+    <div class="border-cell top-right"><img src="assets/images/AUG4759_bw.jpg" alt="Walking through a meadow"></div>
+
+    <div class="border-cell mid-left-upper"><img src="assets/images/AUG4849_bw.jpg" alt="Strolling through the forest"></div>
+    <div class="border-cell mid-right-upper"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
+
+    <main class="content-card">
+      <div class="card-shell">
+        <div class="flip-card" id="flipCard" aria-live="polite">
+          <div class="flip-inner">
+            <div class="flip-face flip-front" tabindex="-1">
+              <p class="eyebrow">Save The Date</p>
+              <h1 class="wedding-names">Emma &amp; Liam</h1>
+              <p class="date">June 21, 2025 &middot; Asheville, NC</p>
+              <p class="description">Tap to reveal the weekend itinerary and travel notes. We can&rsquo;t wait to celebrate with you.</p>
+              <button class="flip-action" type="button" aria-controls="flipCard" aria-label="Show celebration details" aria-expanded="false">View Details</button>
+            </div>
+            <div class="flip-face flip-back" aria-hidden="true" tabindex="-1">
+              <h2>Ceremony Weekend</h2>
+              <ul>
+                <li><strong>Friday:</strong> Welcome gathering at The Greenhouse, 6 PM.</li>
+                <li><strong>Saturday:</strong> Ceremony at Black Balsam Knoll, 4 PM.</li>
+                <li><strong>Sunday:</strong> Farewell brunch downtown, 10 AM.</li>
+              </ul>
+              <p class="travel-note">Flights into AVL airport are easiest. A shuttle schedule will be shared in spring.</p>
+              <button class="flip-action" type="button" aria-controls="flipCard" aria-label="Return to invitation front" aria-expanded="false">Back</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <div class="border-cell mid-left-lower"><img src="assets/images/AUG5177_bw.jpg" alt="Sharing a quiet moment"></div>
+    <div class="border-cell mid-right-lower"><img src="assets/images/AUG5201_bw.jpg" alt="Couple embracing"></div>
+
+    <div class="border-cell bottom-left"><img src="assets/images/AUG5253_bw.jpg" alt="Walking hand in hand"></div>
+    <div class="border-cell bottom-left-center"><img src="assets/images/AUG5279_bw.jpg" alt="Smiling together"></div>
+    <div class="border-cell bottom-right-center"><img src="assets/images/AUG5290_bw.jpg" alt="Dancing under string lights"></div>
+    <div class="border-cell bottom-right"><img src="assets/images/AUG5306_bw.jpg" alt="Laughing near the lake"></div>
+  </div>
+
+  <script>
+    const flipCard = document.getElementById('flipCard');
+    const actionButtons = flipCard ? Array.from(flipCard.querySelectorAll('.flip-action')) : [];
+    const [frontButton, backButton] = actionButtons;
+    const frontFace = flipCard?.querySelector('.flip-front');
+    const backFace = flipCard?.querySelector('.flip-back');
+
+    frontFace?.setAttribute('aria-hidden', 'false');
+    backFace?.setAttribute('aria-hidden', 'true');
+    frontButton?.setAttribute('aria-expanded', 'false');
+    backButton?.setAttribute('aria-expanded', 'false');
+
+    const setButtonState = (isExpanded) => {
+      frontButton?.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+      backButton?.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    };
+
+    const toggleFlip = (event) => {
+      if (!flipCard) return;
+      event?.stopPropagation();
+      const shouldFlip = !flipCard.classList.contains('flipped');
+      flipCard.classList.toggle('flipped', shouldFlip);
+      const isFlipped = flipCard.classList.contains('flipped');
+      frontFace?.setAttribute('aria-hidden', isFlipped ? 'true' : 'false');
+      backFace?.setAttribute('aria-hidden', isFlipped ? 'false' : 'true');
+      setButtonState(isFlipped);
+      const focusTarget = isFlipped ? backFace : frontButton || frontFace;
+      focusTarget?.focus({ preventScroll: true });
+    };
+
+    actionButtons.forEach((button) => {
+      button.addEventListener('click', toggleFlip);
+    });
+
+    flipCard?.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLButtonElement) {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const isFrontFace = target?.closest('.flip-front');
+      if (!flipCard.classList.contains('flipped') && isFrontFace) {
+        toggleFlip(event);
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && flipCard?.classList.contains('flipped')) {
+        event.preventDefault();
+        toggleFlip(event);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `border-flip.html` variant that expands the framed gallery with more photos and an interactive flip invitation card
- create `bordered-gallery-flip.css` to lay out the four-column border grid and style the flip-card experience

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cce9228040832e906327b15ca3e218