### PR TITLE
Animate border images sequentially

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -54,6 +54,24 @@ body {
   border-radius: clamp(16px, 3vw, 28px);
 }
 
+.border-cell.is-ready {
+  opacity: 0;
+  animation: border-cell-in 0.85s ease forwards;
+  animation-delay: var(--border-cell-delay, 0s);
+}
+
+@keyframes border-cell-in {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.97);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 .border-cell::after {
   content: '';
   position: absolute;
@@ -268,6 +286,13 @@ body {
   background: var(--accent);
   color: var(--text-dark);
   transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .border-cell.is-ready {
+    animation: none;
+    opacity: 1;
+  }
 }
 
 @media (max-width: 960px) {

--- a/border-flip.html
+++ b/border-flip.html
@@ -55,6 +55,17 @@
   </div>
 
   <script>
+    const borderCells = Array.from(document.querySelectorAll('.border-cell'));
+    borderCells.forEach((cell, index) => {
+      cell.style.setProperty('--border-cell-delay', `${index * 0.18}s`);
+    });
+
+    requestAnimationFrame(() => {
+      borderCells.forEach((cell) => {
+        cell.classList.add('is-ready');
+      });
+    });
+
     const flipCard = document.getElementById('flipCard');
     const actionButtons = flipCard ? Array.from(flipCard.querySelectorAll('.flip-action')) : [];
     const [frontButton, backButton] = actionButtons;


### PR DESCRIPTION
## Summary
- add a border cell entrance animation so the images appear sequentially
- initialize animation delays with JavaScript to keep the reveal order consistent
- disable the effect when the user prefers reduced motion

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccebda3a48832eaef442747a770e16