### PR TITLE
Ensure border photos fit viewport

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -34,6 +34,7 @@ body {
   width: 100%;
   height: 100vh;
   overflow: hidden;
+  padding: clamp(18px, 4vw, 48px);
 }
 
 .border-cell {
@@ -75,7 +76,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: clamp(24px, 4vw, 56px);
+  margin: 0;
   border: 1px solid rgba(12, 44, 29, 0.16);
 }
 


### PR DESCRIPTION
## Summary
- remove the extra margin on the main content card so the border grid fits within the viewport
- add responsive padding to the border grid so the framed photos remain visible without scrolling

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccec282fbc832e9e42fb5e6d44859e