### PR TITLE
Replace flip card with countdown and slow border reveal

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -7,6 +7,7 @@
   --accent: #ffe3a2;
   --card-radius: clamp(24px, 4vw, 40px);
   --transition: 0.35s ease;
+  --countdown-font: 'Cinzel Decorative', serif;
 }
 
 * {
@@ -56,7 +57,7 @@ body {
 
 .border-cell.is-ready {
   opacity: 0;
-  animation: border-cell-in 0.85s ease forwards;
+  animation: border-cell-in 1.6s ease-out forwards;
   animation-delay: var(--border-cell-delay, 0s);
 }
 
@@ -175,49 +176,6 @@ body {
   pointer-events: none;
 }
 
-.flip-card {
-  width: 100%;
-  height: 100%;
-  perspective: 1200px;
-}
-
-.flip-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  transition: transform 0.6s ease;
-  transform-style: preserve-3d;
-}
-
-.flip-card.flipped .flip-inner {
-  transform: rotateY(180deg);
-}
-
-.flip-face {
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.94);
-  border-radius: clamp(18px, 3vw, 30px);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
-  border: 1.5px solid rgba(12, 44, 29, 0.12);
-  padding: clamp(24px, 4vw, 44px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  backface-visibility: hidden;
-}
-
-.flip-front {
-  background: rgba(255, 255, 255, 0.94);
-}
-
-.flip-back {
-  background: rgba(255, 255, 255, 0.92);
-  transform: rotateY(180deg);
-}
-
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.35em;
@@ -226,66 +184,41 @@ body {
   margin-bottom: clamp(10px, 1.4vw, 16px);
 }
 
-.wedding-names {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: clamp(2.4rem, 5vw, 3.6rem);
-  letter-spacing: 0.06em;
-  margin: 0 0 clamp(12px, 2vw, 20px);
+.countdown-wrapper {
+  position: relative;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: clamp(18px, 3vw, 30px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+  border: 1.5px solid rgba(12, 44, 29, 0.12);
+  padding: clamp(28px, 5vw, 48px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: clamp(18px, 4vw, 32px);
+}
+
+.countdown-number {
+  font-family: var(--countdown-font);
+  font-size: clamp(3.2rem, 10vw, 6rem);
+  letter-spacing: 0.12em;
   color: var(--text-dark);
+  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
-.date {
-  font-size: clamp(1rem, 2vw, 1.3rem);
-  color: var(--text-muted);
-  margin-bottom: clamp(18px, 2vw, 28px);
+.countdown-number.is-transitioning {
+  opacity: 0.6;
+  transform: scale(0.9);
 }
 
-.description,
-.travel-note {
-  margin: 0 0 clamp(18px, 3vw, 28px);
+.countdown-note {
+  margin: 0;
   line-height: 1.6;
-  font-size: clamp(0.95rem, 2vw, 1.1rem);
-}
-
-.flip-back h2 {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: clamp(1.4rem, 3vw, 2rem);
-  margin-bottom: clamp(14px, 2vw, 22px);
-  color: var(--text-dark);
-}
-
-.flip-back ul {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 clamp(18px, 3vw, 26px);
-  width: 100%;
-  color: var(--text-dark);
-  text-align: left;
-  line-height: 1.5;
-}
-
-.flip-back li + li {
-  margin-top: clamp(10px, 2vw, 16px);
-}
-
-.flip-action {
-  border: none;
-  background: var(--text-dark);
-  color: var(--cream);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: clamp(12px, 2.5vw, 16px) clamp(22px, 5vw, 30px);
-  border-radius: 999px;
-  cursor: pointer;
-  transition: background var(--transition), color var(--transition), transform var(--transition);
-}
-
-.flip-action:hover,
-.flip-action:focus-visible {
-  background: var(--accent);
-  color: var(--text-dark);
-  transform: translateY(-2px);
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--text-muted);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/border-flip.html
+++ b/border-flip.html
@@ -21,26 +21,10 @@
 
     <main class="content-card">
       <div class="card-shell">
-        <div class="flip-card" id="flipCard" aria-live="polite">
-          <div class="flip-inner">
-            <div class="flip-face flip-front" tabindex="-1">
-              <p class="eyebrow">Save The Date</p>
-              <h1 class="wedding-names">Emma &amp; Liam</h1>
-              <p class="date">June 21, 2025 &middot; Asheville, NC</p>
-              <p class="description">Tap to reveal the weekend itinerary and travel notes. We can&rsquo;t wait to celebrate with you.</p>
-              <button class="flip-action" type="button" aria-controls="flipCard" aria-label="Show celebration details" aria-expanded="false">View Details</button>
-            </div>
-            <div class="flip-face flip-back" aria-hidden="true" tabindex="-1">
-              <h2>Ceremony Weekend</h2>
-              <ul>
-                <li><strong>Friday:</strong> Welcome gathering at The Greenhouse, 6 PM.</li>
-                <li><strong>Saturday:</strong> Ceremony at Black Balsam Knoll, 4 PM.</li>
-                <li><strong>Sunday:</strong> Farewell brunch downtown, 10 AM.</li>
-              </ul>
-              <p class="travel-note">Flights into AVL airport are easiest. A shuttle schedule will be shared in spring.</p>
-              <button class="flip-action" type="button" aria-controls="flipCard" aria-label="Return to invitation front" aria-expanded="false">Back</button>
-            </div>
-          </div>
+        <div class="countdown-wrapper" aria-live="polite">
+          <p class="eyebrow">Celebration Countdown</p>
+          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
@@ -57,7 +41,7 @@
   <script>
     const borderCells = Array.from(document.querySelectorAll('.border-cell'));
     borderCells.forEach((cell, index) => {
-      cell.style.setProperty('--border-cell-delay', `${index * 0.18}s`);
+      cell.style.setProperty('--border-cell-delay', `${index * 0.35}s`);
     });
 
     requestAnimationFrame(() => {
@@ -66,56 +50,35 @@
       });
     });
 
-    const flipCard = document.getElementById('flipCard');
-    const actionButtons = flipCard ? Array.from(flipCard.querySelectorAll('.flip-action')) : [];
-    const [frontButton, backButton] = actionButtons;
-    const frontFace = flipCard?.querySelector('.flip-front');
-    const backFace = flipCard?.querySelector('.flip-back');
+    const countdownNumber = document.getElementById('countdownNumber');
+    const countdownStart = 10;
+    const countdownNote = document.querySelector('.countdown-note');
+    let currentValue = countdownStart;
 
-    frontFace?.setAttribute('aria-hidden', 'false');
-    backFace?.setAttribute('aria-hidden', 'true');
-    frontButton?.setAttribute('aria-expanded', 'false');
-    backButton?.setAttribute('aria-expanded', 'false');
+    if (countdownNumber) {
+      countdownNumber.textContent = String(currentValue);
 
-    const setButtonState = (isExpanded) => {
-      frontButton?.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
-      backButton?.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
-    };
+      const countdownInterval = window.setInterval(() => {
+        currentValue -= 1;
+        countdownNumber.classList.add('is-transitioning');
 
-    const toggleFlip = (event) => {
-      if (!flipCard) return;
-      event?.stopPropagation();
-      const shouldFlip = !flipCard.classList.contains('flipped');
-      flipCard.classList.toggle('flipped', shouldFlip);
-      const isFlipped = flipCard.classList.contains('flipped');
-      frontFace?.setAttribute('aria-hidden', isFlipped ? 'true' : 'false');
-      backFace?.setAttribute('aria-hidden', isFlipped ? 'false' : 'true');
-      setButtonState(isFlipped);
-      const focusTarget = isFlipped ? backFace : frontButton || frontFace;
-      focusTarget?.focus({ preventScroll: true });
-    };
+        if (currentValue <= 1) {
+          countdownNumber.textContent = '1';
+          countdownNumber.setAttribute('aria-label', 'Countdown finished');
+          window.clearInterval(countdownInterval);
+          if (countdownNote) {
+            countdownNote.textContent = 'It\'s time to celebrate!';
+          }
+        } else {
+          countdownNumber.textContent = String(currentValue);
+          countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
+        }
 
-    actionButtons.forEach((button) => {
-      button.addEventListener('click', toggleFlip);
-    });
-
-    flipCard?.addEventListener('click', (event) => {
-      if (event.target instanceof HTMLButtonElement) {
-        return;
-      }
-      const target = event.target instanceof HTMLElement ? event.target : null;
-      const isFrontFace = target?.closest('.flip-front');
-      if (!flipCard.classList.contains('flipped') && isFrontFace) {
-        toggleFlip(event);
-      }
-    });
-
-    document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && flipCard?.classList.contains('flipped')) {
-        event.preventDefault();
-        toggleFlip(event);
-      }
-    });
+        window.setTimeout(() => {
+          countdownNumber.classList.remove('is-transitioning');
+        }, 200);
+      }, 1000);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the interactive flip card with a countdown display that counts from 10 to 1 and announces completion
- update styles for the new countdown presentation and add gentle transitions for the number changes
- slow the border photo reveal animation for a more gradual entrance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccede72e84832e8ae1da01cf1e1758