### PR TITLE
Improve countdown timing and styling

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -213,17 +213,30 @@ html, body {
   font-weight: 700;
   color: var(--white);
   line-height: 1;
-  text-align: center;
   text-shadow: 0 22px 32px rgba(0,0,0,0.35);
   position: relative;
   z-index: 3;
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  opacity: 0;
+  transform: scale(0.84);
+  transition: opacity 0.45s ease, transform 0.7s var(--ease-med);
+}
+
+.countdown-number.is-visible,
+#countdownDemo.is-visible {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .countdown-square.show-video .countdown-number,
 .countdown-square.show-video #countdownDemo {
   opacity: 0;
-  transform: scale(0.85);
+  transform: scale(0.84);
 }
 
 .countdown-video {


### PR DESCRIPTION
## Summary
- sync the countdown photo reveal cadence with the timer so more frames appear as zero approaches
- animate and scale the countdown number like the index experience, centering it and clearing non-numeric overlay text once counting starts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccef89210c832e8e44d727f6411ae1