### PR TITLE
Load countdown video after animation completes

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -239,7 +239,7 @@ html, body {
   transform: scale(0.84);
 }
 
-.countdown-video {
+.countdown-video { 
   position: absolute;
   inset: clamp(14px, 2.6vw, 30px);
   border-radius: clamp(16px, 2.6vw, 24px);
@@ -253,6 +253,18 @@ html, body {
 
 .countdown-square.show-video .countdown-video {
   opacity: 1;
+}
+
+.countdown-video-fallback {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  transition: opacity 0.4s ease;
+}
+
+.countdown-video.has-video .countdown-video-fallback {
+  opacity: 0;
 }
 
 .countdown-video video {

--- a/countdown.html
+++ b/countdown.html
@@ -24,11 +24,20 @@
     <div class="countdown-layout" id="countdownLayout">
       <div class="countdown-square" id="countdownSquare">
         <div id="countdownDemo" class="countdown-number"></div>
-        <div class="countdown-video" aria-hidden="true">
-          <video muted loop playsinline preload="auto" poster="assets/video-fallback.jpg">
-            <source src="assets/video.mp4" type="video/mp4" />
-            <img src="assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover" />
-          </video>
+        <div
+          class="countdown-video"
+          aria-hidden="true"
+          data-video-src="assets/video.mp4"
+          data-video-type="video/mp4"
+          data-video-poster="assets/video-fallback.jpg"
+        >
+          <img
+            class="countdown-video-fallback"
+            src="assets/video-fallback.jpg"
+            alt="Video fallback"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- defer loading the countdown video until after the countdown animation finishes
- inject the video element dynamically and fade out the fallback image when ready
- ensure the video plays once the countdown concludes while staying within its container

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccf3c8a438832e8557ab170872f9c9