### PR TITLE
Revert border flip page to countdown presentation

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -184,7 +184,7 @@ body {
   margin-bottom: clamp(10px, 1.4vw, 16px);
 }
 
-.card-content {
+.countdown-wrapper {
   position: relative;
   inset: 0;
   background: rgba(255, 255, 255, 0.94);
@@ -200,39 +200,7 @@ body {
   gap: clamp(18px, 4vw, 32px);
 }
 
-.wedding-names {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: clamp(2.4rem, 5vw, 3.4rem);
-  margin: 0;
-  line-height: 1.1;
-  letter-spacing: 0.08em;
-  color: var(--text-dark);
-  text-transform: uppercase;
-}
-
-.wedding-date {
-  margin: 0;
-  font-size: clamp(1rem, 2.4vw, 1.25rem);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.card-countdown {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(8px, 2vw, 16px);
-}
-
-.card-countdown-label {
-  font-size: clamp(0.85rem, 1.8vw, 1rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.card-countdown-value {
+.countdown-number {
   font-family: var(--countdown-font);
   font-size: clamp(3.2rem, 10vw, 6rem);
   letter-spacing: 0.12em;
@@ -241,20 +209,16 @@ body {
   transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
-.card-message {
-  display: grid;
-  gap: clamp(12px, 2vw, 20px);
-  font-size: clamp(1rem, 2.2vw, 1.2rem);
-  line-height: 1.6;
-  color: var(--text-muted);
+.countdown-number.is-transitioning {
+  opacity: 0.6;
+  transform: scale(0.9);
 }
 
-.card-message p {
+.countdown-note {
   margin: 0;
-}
-
-.card-note {
-  font-style: italic;
+  line-height: 1.6;
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--text-muted);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/border-flip.html
+++ b/border-flip.html
@@ -21,19 +21,11 @@
 
     <main class="content-card">
       <div class="card-shell">
-        <article class="card-content" aria-labelledby="weddingNames">
-          <p class="eyebrow">Save the Date</p>
-          <h1 class="wedding-names" id="weddingNames">Lorraine<br>&amp;<br>Christopher</h1>
-          <p class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</p>
-          <div class="card-countdown" aria-live="polite">
-            <span class="card-countdown-label">Countdown to our celebration</span>
-            <span class="card-countdown-value" id="countdown" role="status" aria-live="polite">Loading…</span>
-          </div>
-          <div class="card-message" id="backContent">
-            <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months.</p>
-            <p class="card-note">Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p>
-          </div>
-        </article>
+        <div class="countdown-wrapper" aria-live="polite">
+          <p class="eyebrow">Celebration Countdown</p>
+          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <p class="countdown-note">Counting down the final moments until the big day.</p>
+        </div>
       </div>
     </main>
 
@@ -58,30 +50,34 @@
       });
     });
 
-    const countdownEl = document.getElementById('countdown');
-    if (countdownEl) {
-      const updateCountdown = () => {
-        const target = new Date('2026-09-12T00:00:00-07:00');
-        const diff = target.getTime() - Date.now();
+    const countdownNumber = document.getElementById('countdownNumber');
+    const countdownStart = 10;
+    const countdownNote = document.querySelector('.countdown-note');
+    let currentValue = countdownStart;
 
-        if (diff <= 0) {
-          countdownEl.textContent = "It's today!";
-          countdownEl.setAttribute('aria-label', "It's today!");
-          window.clearInterval(intervalId);
-          return;
+    if (countdownNumber) {
+      countdownNumber.textContent = String(currentValue);
+
+      const countdownInterval = window.setInterval(() => {
+        currentValue -= 1;
+        countdownNumber.classList.add('is-transitioning');
+
+        if (currentValue <= 1) {
+          countdownNumber.textContent = '1';
+          countdownNumber.setAttribute('aria-label', 'Countdown finished');
+          window.clearInterval(countdownInterval);
+          if (countdownNote) {
+            countdownNote.textContent = 'It\'s time to celebrate!';
+          }
+        } else {
+          countdownNumber.textContent = String(currentValue);
+          countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
         }
 
-        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-        const minutes = Math.floor((diff / (1000 * 60)) % 60);
-        const seconds = Math.floor((diff / 1000) % 60);
-        const formatted = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-        countdownEl.textContent = formatted;
-        countdownEl.setAttribute('aria-label', `Countdown: ${formatted}`);
-      };
-
-      updateCountdown();
-      const intervalId = window.setInterval(updateCountdown, 1000);
+        window.setTimeout(() => {
+          countdownNumber.classList.remove('is-transitioning');
+        }, 200);
+      }, 1000);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- restore the border flip page content to the countdown-only experience
- revert the associated flip card styles to the countdown wrapper and number animations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccf76ffc58832e8c8e548bac74af7a