### PR TITLE
Load video into countdown container after completion

### DIFF
--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -231,6 +231,8 @@ document.addEventListener('DOMContentLoaded', () => {
       videoEl.style.height = '100%';
       videoEl.style.display = 'block';
       videoEl.style.objectFit = 'cover';
+      videoEl.style.maxWidth = '100%';
+      videoEl.style.maxHeight = '100%';
 
       const posterUrl = videoWrapper.dataset.videoPoster;
       if (posterUrl) {
@@ -254,6 +256,12 @@ document.addEventListener('DOMContentLoaded', () => {
         videoEl.removeEventListener('error', handleError);
         if (resultVideo) {
           videoWrapper.classList.add('has-video');
+          const fallbackImage = videoWrapper.querySelector('.countdown-video-fallback');
+          if (fallbackImage) {
+            fallbackImage.remove();
+          }
+          videoWrapper.style.width = '100%';
+          videoWrapper.style.height = '100%';
           video = resultVideo;
         }
         resolve(resultVideo);


### PR DESCRIPTION
## Summary
- ensure the countdown video element is sized to its container and remove the fallback image once ready
- keep the video wrapper constrained to the countdown square before starting playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf83523b4832eabb263b0b89a0e5e