### PR TITLE
Center countdown numbers and remove celebration copy

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -206,19 +206,17 @@ body {
   letter-spacing: 0.12em;
   color: var(--text-dark);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: clamp(160px, 24vw, 240px);
   transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
 .countdown-number.is-transitioning {
-  opacity: 0.6;
-  transform: scale(0.9);
-}
-
-.countdown-note {
-  margin: 0;
-  line-height: 1.6;
-  font-size: clamp(1rem, 2.2vw, 1.3rem);
-  color: var(--text-muted);
+  opacity: 0;
+  transform: scale(1.18);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -219,18 +219,18 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
   width: 100%;
   height: 100%;
   text-align: center;
   opacity: 0;
-  transform: scale(0.84);
-  transition: opacity 0.45s ease, transform 0.7s var(--ease-med);
+  transform: scale(0.65);
+  animation: none;
 }
 
 .countdown-number.is-visible,
 #countdownDemo.is-visible {
-  opacity: 1;
-  transform: scale(1);
+  animation: countdownFadeScale 0.85s var(--ease-med) forwards;
 }
 
 .countdown-square.show-video .countdown-number,
@@ -369,6 +369,21 @@ html, body {
 
 .countdown-image-stack.fade-out::after {
   opacity: 0;
+}
+
+@keyframes countdownFadeScale {
+  0% {
+    opacity: 0;
+    transform: scale(0.65);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes countdownHit {

--- a/assets/js/countdown-demo.js
+++ b/assets/js/countdown-demo.js
@@ -304,7 +304,7 @@ document.addEventListener('DOMContentLoaded', () => {
     audioCtx.resume().catch(() => {});
 
     let n = countdownStartValue;
-    numberEl.style.transition = 'opacity 0.45s ease, transform 0.7s var(--ease-med), font-size 0.7s var(--ease-med)';
+    numberEl.style.removeProperty('transition');
     updateNumber(n);
     applyScheduledReveal();
     playBeat();

--- a/border-flip.html
+++ b/border-flip.html
@@ -22,9 +22,7 @@
     <main class="content-card">
       <div class="card-shell">
         <div class="countdown-wrapper" aria-live="polite">
-          <p class="eyebrow">Celebration Countdown</p>
           <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
-          <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
@@ -52,7 +50,6 @@
 
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
-    const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
 
     if (countdownNumber) {
@@ -66,9 +63,6 @@
           countdownNumber.textContent = '1';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
-          if (countdownNote) {
-            countdownNote.textContent = 'It\'s time to celebrate!';
-          }
         } else {
           countdownNumber.textContent = String(currentValue);
           countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);


### PR DESCRIPTION
## Summary
- center the countdown numerals and give them an enlarged fade-in animation on the demo screen
- adjust bordered gallery countdown styling to keep the number centered and remove unused celebration text
- drop celebratory copy from the flip layout and clean up the countdown script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf8ba3fe8832eafa912def40d408c