### PR TITLE
Restore countdown card on border flip page

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -206,42 +206,19 @@ body {
   letter-spacing: 0.12em;
   color: var(--text-dark);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  min-height: clamp(160px, 24vw, 240px);
   transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
 .countdown-number.is-transitioning {
-  opacity: 0;
-  transform: scale(1.18);
+  opacity: 0.6;
+  transform: scale(0.9);
 }
 
-.video-gallery {
-  display: grid;
-  gap: clamp(16px, 4vw, 28px);
-  width: 100%;
-  max-width: 100%;
-}
-
-.video-frame {
-  width: 100%;
-  max-width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.video-frame video {
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  max-height: 100%;
-  border-radius: clamp(18px, 3vw, 30px);
-  background: #000;
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+.countdown-note {
+  margin: 0;
+  line-height: 1.6;
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--text-muted);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/border-flip.html
+++ b/border-flip.html
@@ -21,7 +21,10 @@
 
     <main class="content-card">
       <div class="card-shell">
+        <div class="countdown-wrapper" aria-live="polite">
+          <p class="eyebrow">Celebration Countdown</p>
           <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
@@ -47,44 +50,10 @@
       });
     });
 
-    const countdownWrapper = document.querySelector('.countdown-wrapper');
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
+    const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
-    let hasDisplayedVideos = false;
-
-    const showVideos = () => {
-      if (hasDisplayedVideos || !cardShell) {
-        return;
-      }
-
-      const sources = videoSources.length ? videoSources : fallbackVideos;
-
-      if (!sources.length) {
-        return;
-      }
-
-      const videoContainer = document.createElement('div');
-      videoContainer.className = 'video-gallery';
-
-      sources.forEach((src, index) => {
-        const videoWrapper = document.createElement('div');
-        videoWrapper.className = 'video-frame';
-
-        const video = document.createElement('video');
-        video.src = src;
-        video.controls = true;
-        video.preload = 'metadata';
-        video.playsInline = true;
-        video.setAttribute('aria-label', `Celebration video ${index + 1}`);
-
-        videoWrapper.appendChild(video);
-        videoContainer.appendChild(videoWrapper);
-      });
-
-      cardShell.replaceChildren(videoContainer);
-      hasDisplayedVideos = true;
-    };
 
     if (countdownNumber) {
       countdownNumber.textContent = String(currentValue);
@@ -93,10 +62,13 @@
         currentValue -= 1;
         countdownNumber.classList.add('is-transitioning');
 
-        if (currentValue <= 0) {
-          countdownNumber.textContent = '0';
+        if (currentValue <= 1) {
+          countdownNumber.textContent = '1';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
+          if (countdownNote) {
+            countdownNote.textContent = 'It\'s time to celebrate!';
+          }
         } else {
           countdownNumber.textContent = String(currentValue);
           countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);


### PR DESCRIPTION
## Summary
- revert the border flip page to the countdown card presentation with celebratory note
- remove unused celebration video logic and restore countdown completion message
- simplify styles by restoring countdown transitions and note styling, removing video gallery rules

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68ccfb827798832e977834e10a098f4e