### PR TITLE
Show celebration video after countdown on border flip page

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -200,6 +200,18 @@ body {
   gap: clamp(18px, 4vw, 32px);
 }
 
+.countdown-wrapper.has-video {
+  padding: 0;
+  background: none;
+  box-shadow: none;
+  border: none;
+  gap: 0;
+}
+
+.countdown-wrapper.has-video::before {
+  content: none;
+}
+
 .countdown-number {
   font-family: var(--countdown-font);
   font-size: clamp(3.2rem, 10vw, 6rem);
@@ -212,6 +224,14 @@ body {
 .countdown-number.is-transitioning {
   opacity: 0.6;
   transform: scale(0.9);
+}
+
+.countdown-video {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+  display: block;
 }
 
 .countdown-note {

--- a/border-flip.html
+++ b/border-flip.html
@@ -50,10 +50,30 @@
       });
     });
 
+    const countdownWrapper = document.querySelector('.countdown-wrapper');
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
     const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
+
+    const showCelebrationVideo = () => {
+      if (!countdownWrapper) {
+        return;
+      }
+
+      countdownWrapper.classList.add('has-video');
+      countdownWrapper.innerHTML = '';
+
+      const celebrationVideo = document.createElement('video');
+      celebrationVideo.className = 'countdown-video';
+      celebrationVideo.src = 'assets/video.mp4';
+      celebrationVideo.autoplay = true;
+      celebrationVideo.loop = true;
+      celebrationVideo.muted = true;
+      celebrationVideo.setAttribute('playsinline', '');
+
+      countdownWrapper.appendChild(celebrationVideo);
+    };
 
     if (countdownNumber) {
       countdownNumber.textContent = String(currentValue);
@@ -62,13 +82,16 @@
         currentValue -= 1;
         countdownNumber.classList.add('is-transitioning');
 
-        if (currentValue <= 1) {
-          countdownNumber.textContent = '1';
+        if (currentValue <= 0) {
+          countdownNumber.textContent = '0';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
           if (countdownNote) {
             countdownNote.textContent = 'It\'s time to celebrate!';
           }
+          window.setTimeout(() => {
+            showCelebrationVideo();
+          }, 400);
         } else {
           countdownNumber.textContent = String(currentValue);
           countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);


### PR DESCRIPTION
## Summary
- replace the border flip countdown with a celebration video once the timer finishes
- adjust the countdown logic to end at zero before loading the video asset
- add styling so the embedded video fills the countdown container cleanly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccfd1b86ac832eac18a589f04918d6