### PR TITLE
Keep celebration video inside countdown card

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -201,15 +201,27 @@ body {
 }
 
 .countdown-wrapper.has-video {
-  padding: 0;
-  background: none;
-  box-shadow: none;
-  border: none;
-  gap: 0;
+  padding: clamp(18px, 4vw, 32px);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+  border: 1.5px solid rgba(12, 44, 29, 0.12);
+  gap: clamp(12px, 3vw, 20px);
 }
 
 .countdown-wrapper.has-video::before {
   content: none;
+}
+
+.countdown-video-frame {
+  width: 100%;
+  max-width: 100%;
+  border-radius: clamp(16px, 3vw, 28px);
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
 }
 
 .countdown-number {
@@ -229,8 +241,7 @@ body {
 .countdown-video {
   width: 100%;
   height: 100%;
-  border-radius: inherit;
-  object-fit: cover;
+  object-fit: contain;
   display: block;
 }
 

--- a/border-flip.html
+++ b/border-flip.html
@@ -64,6 +64,9 @@
       countdownWrapper.classList.add('has-video');
       countdownWrapper.innerHTML = '';
 
+      const videoFrame = document.createElement('div');
+      videoFrame.className = 'countdown-video-frame';
+
       const celebrationVideo = document.createElement('video');
       celebrationVideo.className = 'countdown-video';
       celebrationVideo.src = 'assets/video.mp4';
@@ -72,7 +75,8 @@
       celebrationVideo.muted = true;
       celebrationVideo.setAttribute('playsinline', '');
 
-      countdownWrapper.appendChild(celebrationVideo);
+      videoFrame.appendChild(celebrationVideo);
+      countdownWrapper.appendChild(videoFrame);
     };
 
     if (countdownNumber) {


### PR DESCRIPTION
## Summary
- keep the celebration video within the countdown card by wrapping it in a dedicated frame element
- style the video frame so the clip maintains its aspect ratio without expanding to full screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccfee59448832eb3bcfaf1f97279ef