### PR TITLE
Add countdown and video intro flow to border page

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -6,6 +6,9 @@
   --text-muted: rgba(12, 44, 29, 0.72);
   --accent: #ffe3a2;
   --transition: 0.35s ease;
+  --card-radius: clamp(20px, 4vw, 36px);
+  --card-border: rgba(12, 44, 29, 0.14);
+  --countdown-font: 'Cinzel Decorative', serif;
 }
 
 * {
@@ -117,6 +120,229 @@ body {
 .content-inner {
   text-align: center;
   max-width: 420px;
+}
+
+.card-shell {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+  min-height: clamp(320px, 52vw, 520px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-shell > * {
+  width: 100%;
+}
+
+.countdown-wrapper {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--card-radius);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
+  border: 1.5px solid var(--card-border);
+  padding: clamp(28px, 5vw, 48px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: clamp(18px, 4vw, 30px);
+}
+
+.countdown-wrapper.has-video {
+  gap: clamp(12px, 3vw, 20px);
+  padding: clamp(18px, 4vw, 32px);
+}
+
+.countdown-number {
+  font-family: var(--countdown-font);
+  font-size: clamp(3rem, 10vw, 6rem);
+  letter-spacing: 0.12em;
+  color: var(--text-dark);
+  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+.countdown-number.is-transitioning {
+  opacity: 0.6;
+  transform: scale(0.9);
+}
+
+.countdown-note {
+  margin: 0;
+  line-height: 1.6;
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--text-muted);
+}
+
+.countdown-video-frame {
+  width: 100%;
+  max-width: 480px;
+  border-radius: calc(var(--card-radius) - clamp(6px, 1.5vw, 12px));
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
+  border: 1.5px solid var(--card-border);
+}
+
+.countdown-video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.flip-card {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  min-height: clamp(300px, 55vw, 520px);
+  perspective: 1200px;
+  cursor: pointer;
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.7s ease;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped .flip-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-front,
+.flip-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--text-dark);
+  border-radius: var(--card-radius);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
+  border: 1.5px solid var(--card-border);
+  padding: clamp(24px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.flip-front:hover {
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.24);
+  transform: translateY(-3px);
+}
+
+.flip-back {
+  transform: rotateY(180deg);
+  text-align: left;
+  gap: clamp(12px, 2.6vw, 22px);
+}
+
+.wedding-names {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: 0.08em;
+  color: var(--text-dark);
+}
+
+.wedding-date {
+  font-size: clamp(1.1rem, 2.8vw, 1.4rem);
+  color: var(--emerald-mid);
+  letter-spacing: 0.04em;
+}
+
+.flip-countdown {
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  color: var(--text-muted);
+}
+
+.flip-back p {
+  margin: 0;
+  line-height: 1.6;
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+}
+
+.cant-attend-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--emerald-mid);
+  color: var(--cream);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.cant-attend-btn:hover,
+.cant-attend-btn:focus-visible {
+  background: var(--emerald-dark);
+  transform: translateY(-1px);
+}
+
+.card-form-container {
+  width: 100%;
+}
+
+.card-form-container form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 1rem;
+  color: var(--text-dark);
+}
+
+.card-form-container input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(12, 44, 29, 0.2);
+  font-size: 1rem;
+}
+
+.card-form-container button[type='submit'] {
+  align-self: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--emerald-mid);
+  color: var(--cream);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.card-form-container button[type='submit']:hover,
+.card-form-container button[type='submit']:focus-visible {
+  background: var(--emerald-dark);
+  transform: translateY(-1px);
+}
+
+.thank-you-message {
+  margin: 0;
+  text-align: center;
+  font-size: 1rem;
+  color: var(--emerald-mid);
+  font-weight: 600;
+}
+
+.form-error-message {
+  color: #a23a3a;
 }
 
 .eyebrow {

--- a/border.html
+++ b/border.html
@@ -17,15 +17,12 @@
 
     <div class="border-cell middle-left"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
     <main class="content-card">
-      <div class="content-inner">
-        <p class="eyebrow">Save The Date</p>
-        <h1>Emma &amp; Liam</h1>
-        <p class="date">June 21, 2025 &middot; Asheville, NC</p>
-        <p class="description">
-          Join us for a weekend of celebration surrounded by the beauty of the Blue Ridge Mountains.
-          We can&rsquo;t wait to share this moment with you.
-        </p>
-        <a class="cta" href="index.html">View Invitation</a>
+      <div class="card-shell" id="cardShell">
+        <div class="countdown-wrapper" aria-live="polite">
+          <p class="eyebrow">Celebration Countdown</p>
+          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <p class="countdown-note">Counting down the final moments until the big day.</p>
+        </div>
       </div>
     </main>
     <div class="border-cell middle-right"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
@@ -46,6 +43,195 @@
         cell.classList.add('is-ready');
       });
     });
+
+    const cardShell = document.getElementById('cardShell');
+    const countdownWrapper = cardShell?.querySelector('.countdown-wrapper');
+    const countdownNumber = document.getElementById('countdownNumber');
+    const countdownNote = countdownWrapper?.querySelector('.countdown-note');
+    const countdownStart = 10;
+    let currentValue = countdownStart;
+
+    const createFlipCardMarkup = () => {
+      return `
+        <div class="flip-card" aria-live="polite">
+          <div class="flip-inner">
+            <div class="flip-front">
+              <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
+              <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
+              <div id="countdown" class="flip-countdown"></div>
+            </div>
+            <div class="flip-back">
+              <div id="backContent">
+                <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p><br>
+                <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
+              </div>
+              <div id="cantAttendFormContainer" class="card-form-container" style="display:none;">
+                <form action="https://script.google.com/macros/s/AKfycbw1oW3-NLd95psh53-YJFoUoa80b1jeyw9oEXX0TWffxMEyauwYvn6aVOn0UJdZgZF2IQ/exec" method="post">
+                  <label>
+                    Name: <input type="text" name="name" required>
+                  </label><br>
+                  <label>
+                    Email: <input type="email" name="email" required>
+                  </label><br><br>
+                  <button type="submit">Send</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+    };
+
+    const attachFlipCardInteractions = () => {
+      const flipCard = cardShell?.querySelector('.flip-card');
+      const countdownEl = cardShell?.querySelector('#countdown');
+      const cantAttendBtn = cardShell?.querySelector('#showCantAttendForm');
+      const backContent = cardShell?.querySelector('#backContent');
+      const formContainer = cardShell?.querySelector('#cantAttendFormContainer');
+      const form = formContainer?.querySelector('form');
+
+      if (flipCard) {
+        flipCard.addEventListener('click', (event) => {
+          const isInteractiveElement = (event.target instanceof HTMLElement) &&
+            (event.target.closest('form') || event.target.closest('.cant-attend-btn'));
+          if (isInteractiveElement) {
+            return;
+          }
+          flipCard.classList.toggle('flipped');
+        });
+      }
+
+      if (cantAttendBtn && backContent && formContainer) {
+        cantAttendBtn.addEventListener('click', () => {
+          backContent.setAttribute('hidden', '');
+          formContainer.style.display = 'block';
+        });
+      }
+
+      if (form && formContainer) {
+        const submitButton = form.querySelector('button[type="submit"]');
+        let isSubmitting = false;
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          if (isSubmitting) {
+            return;
+          }
+          isSubmitting = true;
+
+          if (submitButton instanceof HTMLButtonElement) {
+            submitButton.disabled = true;
+            submitButton.textContent = 'Sending...';
+          }
+
+          try {
+            const formData = new FormData(form);
+            await fetch(form.action, { method: 'POST', body: formData, mode: 'no-cors' });
+            formContainer.innerHTML = '<p class="thank-you-message">Thank you for letting us know. We will keep you updated!</p>';
+          } catch (error) {
+            let errorMessage = formContainer.querySelector('.form-error-message');
+            if (!errorMessage) {
+              errorMessage = document.createElement('p');
+              errorMessage.className = 'thank-you-message form-error-message';
+              formContainer.appendChild(errorMessage);
+            }
+            errorMessage.textContent = 'Submission failed. Please try again later.';
+
+            if (submitButton instanceof HTMLButtonElement) {
+              submitButton.disabled = false;
+              submitButton.textContent = 'Send';
+            }
+            isSubmitting = false;
+          }
+        });
+      }
+
+      if (countdownEl) {
+        const target = new Date('2026-09-12T00:00:00-07:00');
+        const updateCountdown = () => {
+          const diff = target.getTime() - Date.now();
+          if (diff <= 0) {
+            countdownEl.textContent = "It's today!";
+            return;
+          }
+          const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+          const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+          const minutes = Math.floor((diff / (1000 * 60)) % 60);
+          const seconds = Math.floor((diff / 1000) % 60);
+          countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+        };
+        updateCountdown();
+        window.setInterval(updateCountdown, 1000);
+      }
+    };
+
+    const showFlipCard = () => {
+      if (!cardShell) return;
+      cardShell.innerHTML = createFlipCardMarkup();
+      attachFlipCardInteractions();
+    };
+
+    const showCelebrationVideo = () => {
+      if (!cardShell) return;
+      cardShell.innerHTML = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'countdown-wrapper has-video';
+
+      const videoFrame = document.createElement('div');
+      videoFrame.className = 'countdown-video-frame';
+
+      const celebrationVideo = document.createElement('video');
+      celebrationVideo.className = 'countdown-video';
+      celebrationVideo.src = 'assets/video.mp4';
+      celebrationVideo.autoplay = true;
+      celebrationVideo.muted = true;
+      celebrationVideo.playsInline = true;
+      celebrationVideo.controls = true;
+
+      celebrationVideo.addEventListener('ended', () => {
+        showFlipCard();
+      }, { once: true });
+
+      videoFrame.appendChild(celebrationVideo);
+      wrapper.appendChild(videoFrame);
+
+      const videoNote = document.createElement('p');
+      videoNote.className = 'countdown-note';
+      videoNote.textContent = 'A quick glimpse before the celebration details appear.';
+      wrapper.appendChild(videoNote);
+
+      cardShell.appendChild(wrapper);
+    };
+
+    if (countdownNumber && countdownWrapper) {
+      countdownNumber.textContent = String(currentValue);
+      const countdownInterval = window.setInterval(() => {
+        currentValue -= 1;
+        countdownNumber.classList.add('is-transitioning');
+
+        if (currentValue <= 0) {
+          countdownNumber.textContent = '0';
+          countdownNumber.setAttribute('aria-label', 'Countdown finished');
+          window.clearInterval(countdownInterval);
+          if (countdownNote) {
+            countdownNote.textContent = "It's time to celebrate!";
+          }
+          window.setTimeout(() => {
+            showCelebrationVideo();
+          }, 400);
+        } else {
+          countdownNumber.textContent = String(currentValue);
+          countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
+        }
+
+        window.setTimeout(() => {
+          countdownNumber.classList.remove('is-transitioning');
+        }, 200);
+      }, 1000);
+    } else {
+      showFlipCard();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the static border card with a three-stage experience: countdown, video preview, then the interactive flip card from the main invitation
- add JavaScript to manage the countdown, video playback transition, and flip-card/form interactions
- extend the bordered gallery styles to support the countdown layout, video frame, and imported flip-card design elements

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ccffb58f34832ea27a0ac5d37bea74