### PR TITLE
Expand celebration video frame on border flip

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -167,6 +167,11 @@ body {
   justify-content: center;
 }
 
+.card-shell.is-video {
+  width: min(620px, 100%);
+  padding: clamp(24px, 3.5vw, 44px);
+}
+
 .card-shell::before {
   content: '';
   position: absolute;
@@ -206,6 +211,7 @@ body {
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
   border: 1.5px solid rgba(12, 44, 29, 0.12);
   gap: clamp(12px, 3vw, 20px);
+  max-width: min(560px, 100%);
 }
 
 .countdown-wrapper.has-video::before {
@@ -214,7 +220,7 @@ body {
 
 .countdown-video-frame {
   width: 100%;
-  max-width: 100%;
+  max-width: 540px;
   border-radius: clamp(16px, 3vw, 28px);
   overflow: hidden;
   aspect-ratio: 16 / 9;

--- a/border-flip.html
+++ b/border-flip.html
@@ -51,6 +51,7 @@
     });
 
     const countdownWrapper = document.querySelector('.countdown-wrapper');
+    const cardShell = countdownWrapper ? countdownWrapper.closest('.card-shell') : null;
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
     const countdownNote = document.querySelector('.countdown-note');
@@ -77,6 +78,10 @@
 
       videoFrame.appendChild(celebrationVideo);
       countdownWrapper.appendChild(videoFrame);
+
+      if (cardShell) {
+        cardShell.classList.add('is-video');
+      }
     };
 
     if (countdownNumber) {


### PR DESCRIPTION
## Summary
- expand the card shell and countdown wrapper sizing when the celebration video appears
- enlarge the video frame while keeping its 16:9 aspect ratio and limit the maximum width for balance
- add a JavaScript hook to flag the card shell so the wider styling applies only during video playback

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd006ea22c832e9a5d71fa0b1d6756