### PR TITLE
Show save-the-date details after border flip video

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -218,6 +218,15 @@ body {
   content: none;
 }
 
+.countdown-wrapper.has-details {
+  background: rgba(255, 255, 255, 0.96);
+  border: 1.5px solid rgba(12, 44, 29, 0.12);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+  padding: clamp(32px, 5vw, 52px);
+  gap: clamp(14px, 4vw, 28px);
+  align-items: center;
+}
+
 .countdown-video-frame {
   width: 100%;
   max-width: 540px;
@@ -256,6 +265,77 @@ body {
   line-height: 1.6;
   font-size: clamp(1rem, 2.2vw, 1.3rem);
   color: var(--text-muted);
+}
+
+.save-date-title {
+  font-family: var(--countdown-font);
+  font-size: clamp(2.2rem, 7vw, 3.8rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dark);
+  margin: 0;
+  text-align: center;
+}
+
+.save-date-title span {
+  display: inline-block;
+  margin: 0 clamp(8px, 1.6vw, 14px);
+}
+
+.save-date-date {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.8vw, 1.4rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(12, 44, 29, 0.82);
+  text-align: center;
+}
+
+.save-date-countdown {
+  width: 100%;
+}
+
+.countdown-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: clamp(12px, 3vw, 20px);
+}
+
+.countdown-segment {
+  background: rgba(12, 44, 29, 0.08);
+  border-radius: clamp(14px, 3vw, 20px);
+  padding: clamp(14px, 3.4vw, 22px) clamp(12px, 3vw, 18px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 14px 26px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.countdown-value {
+  font-family: var(--countdown-font);
+  font-size: clamp(2.2rem, 8vw, 3.4rem);
+  letter-spacing: 0.12em;
+  color: var(--text-dark);
+}
+
+.countdown-label {
+  margin-top: clamp(6px, 1.2vw, 10px);
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: clamp(0.62rem, 1.6vw, 0.78rem);
+  color: var(--text-muted);
+}
+
+.save-date-note {
+  max-width: 420px;
+  text-align: center;
+}
+
+.card-shell.is-details {
+  width: min(620px, 100%);
+  padding: clamp(28px, 5vw, 56px);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/border-flip.html
+++ b/border-flip.html
@@ -57,12 +57,141 @@
     const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
 
+    const showSaveTheDateDetails = () => {
+      if (!countdownWrapper) {
+        return;
+      }
+
+      countdownWrapper.classList.remove('has-video');
+      countdownWrapper.classList.add('has-details');
+      countdownWrapper.innerHTML = '';
+
+      const eyebrow = document.createElement('p');
+      eyebrow.className = 'eyebrow';
+      eyebrow.textContent = 'Save the Date';
+
+      const title = document.createElement('h1');
+      title.className = 'save-date-title';
+      title.innerHTML = 'Lorraine <span>&amp;</span> Christopher';
+
+      const dateLine = document.createElement('p');
+      dateLine.className = 'save-date-date';
+      dateLine.textContent = 'September 12, 2026 · Portola, California';
+
+      const countdownContainer = document.createElement('div');
+      countdownContainer.className = 'save-date-countdown';
+      countdownContainer.setAttribute('aria-live', 'polite');
+      countdownContainer.setAttribute('role', 'timer');
+
+      const countdownGrid = document.createElement('div');
+      countdownGrid.className = 'countdown-grid';
+      countdownContainer.appendChild(countdownGrid);
+
+      const countdownValues = {};
+      const countdownSegments = [
+        ['days', 'Days'],
+        ['hours', 'Hours'],
+        ['minutes', 'Minutes'],
+        ['seconds', 'Seconds'],
+      ];
+
+      countdownSegments.forEach(([unit, label]) => {
+        const segment = document.createElement('div');
+        segment.className = 'countdown-segment';
+
+        const value = document.createElement('div');
+        value.className = 'countdown-value';
+        value.textContent = '00';
+        value.setAttribute('data-unit', unit);
+
+        const unitLabel = document.createElement('div');
+        unitLabel.className = 'countdown-label';
+        unitLabel.textContent = label;
+
+        segment.appendChild(value);
+        segment.appendChild(unitLabel);
+        countdownGrid.appendChild(segment);
+        countdownValues[unit] = value;
+      });
+
+      const note = document.createElement('p');
+      note.className = 'countdown-note save-date-note';
+      note.textContent = "Formal invitation to follow. We can't wait to celebrate with you!";
+
+      countdownWrapper.appendChild(eyebrow);
+      countdownWrapper.appendChild(title);
+      countdownWrapper.appendChild(dateLine);
+      countdownWrapper.appendChild(countdownContainer);
+      countdownWrapper.appendChild(note);
+
+      if (cardShell) {
+        cardShell.classList.remove('is-video');
+        cardShell.classList.add('is-details');
+      }
+
+      const eventDate = new Date('2026-09-12T16:00:00-07:00');
+
+      const formatNumber = (value) => {
+        const stringValue = String(Math.max(0, value));
+        return stringValue.padStart(2, '0');
+      };
+
+      const updateCountdown = () => {
+        const now = new Date();
+        const totalMilliseconds = eventDate.getTime() - now.getTime();
+
+        if (totalMilliseconds <= 0) {
+          countdownValues.days.textContent = '00';
+          countdownValues.hours.textContent = '00';
+          countdownValues.minutes.textContent = '00';
+          countdownValues.seconds.textContent = '00';
+          note.textContent = 'Today is the day—see you soon!';
+          countdownContainer.setAttribute('aria-label', 'Countdown complete');
+          return false;
+        }
+
+        const totalSeconds = Math.floor(totalMilliseconds / 1000);
+        const secondsInDay = 60 * 60 * 24;
+        const secondsInHour = 60 * 60;
+        const secondsInMinute = 60;
+
+        const days = Math.floor(totalSeconds / secondsInDay);
+        const hours = Math.floor((totalSeconds % secondsInDay) / secondsInHour);
+        const minutes = Math.floor((totalSeconds % secondsInHour) / secondsInMinute);
+        const seconds = totalSeconds % secondsInMinute;
+
+        countdownValues.days.textContent = formatNumber(days);
+        countdownValues.hours.textContent = formatNumber(hours);
+        countdownValues.minutes.textContent = formatNumber(minutes);
+        countdownValues.seconds.textContent = formatNumber(seconds);
+
+        countdownContainer.setAttribute(
+          'aria-label',
+          `${days} days, ${hours} hours, ${minutes} minutes, and ${seconds} seconds until the celebration`
+        );
+
+        return true;
+      };
+
+      const hasTimeRemaining = updateCountdown();
+
+      if (hasTimeRemaining) {
+        const eventCountdownInterval = window.setInterval(() => {
+          const stillCounting = updateCountdown();
+          if (!stillCounting) {
+            window.clearInterval(eventCountdownInterval);
+          }
+        }, 1000);
+      }
+    };
+
     const showCelebrationVideo = () => {
       if (!countdownWrapper) {
         return;
       }
 
       countdownWrapper.classList.add('has-video');
+      countdownWrapper.classList.remove('has-details');
       countdownWrapper.innerHTML = '';
 
       const videoFrame = document.createElement('div');
@@ -72,14 +201,22 @@
       celebrationVideo.className = 'countdown-video';
       celebrationVideo.src = 'assets/video.mp4';
       celebrationVideo.autoplay = true;
-      celebrationVideo.loop = true;
+      celebrationVideo.loop = false;
       celebrationVideo.muted = true;
       celebrationVideo.setAttribute('playsinline', '');
+
+      celebrationVideo.addEventListener('ended', () => {
+        showSaveTheDateDetails();
+      });
+      celebrationVideo.addEventListener('error', () => {
+        showSaveTheDateDetails();
+      }, { once: true });
 
       videoFrame.appendChild(celebrationVideo);
       countdownWrapper.appendChild(videoFrame);
 
       if (cardShell) {
+        cardShell.classList.remove('is-details');
         cardShell.classList.add('is-video');
       }
     };


### PR DESCRIPTION
## Summary
- replace the looping celebration video with a single playthrough that transitions to a save-the-date panel
- render wedding details and a live countdown timer once the video ends or fails to load
- add styling for the post-video save-the-date layout within the bordered flip design

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd022ff01c832e9bec94c37e7ae4a3