### PR TITLE
Restore invite flip card after celebration video

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -6,6 +6,7 @@
   --text-muted: rgba(12, 44, 29, 0.72);
   --accent: #ffe3a2;
   --card-radius: clamp(24px, 4vw, 40px);
+  --card-border: rgba(12, 44, 29, 0.14);
   --transition: 0.35s ease;
   --countdown-font: 'Cinzel Decorative', serif;
 }
@@ -167,6 +168,11 @@ body {
   justify-content: center;
 }
 
+.card-shell.has-flip {
+  perspective: 1200px;
+  cursor: pointer;
+}
+
 .card-shell.is-video {
   width: min(620px, 100%);
   padding: clamp(24px, 3.5vw, 44px);
@@ -216,6 +222,153 @@ body {
 
 .countdown-wrapper.has-video::before {
   content: none;
+}
+
+.flip-card {
+  width: 100%;
+  min-height: clamp(320px, 60vw, 520px);
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.7s ease;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped .flip-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-front,
+.flip-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--text-dark);
+  border-radius: var(--card-radius);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
+  border: 1.5px solid var(--card-border);
+  padding: clamp(24px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.flip-front:hover {
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.24);
+  transform: translateY(-3px);
+}
+
+.flip-back {
+  transform: rotateY(180deg);
+  text-align: left;
+  gap: clamp(12px, 2.6vw, 22px);
+}
+
+.wedding-names {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: 0.08em;
+  color: var(--text-dark);
+}
+
+.wedding-date {
+  font-size: clamp(1.1rem, 2.8vw, 1.4rem);
+  color: var(--emerald-mid);
+  letter-spacing: 0.04em;
+}
+
+.flip-countdown {
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  color: var(--text-muted);
+}
+
+.flip-back p {
+  margin: 0;
+  line-height: 1.6;
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+}
+
+.cant-attend-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--emerald-mid);
+  color: var(--cream);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.cant-attend-btn:hover,
+.cant-attend-btn:focus-visible {
+  background: var(--emerald-dark);
+  transform: translateY(-1px);
+}
+
+.card-form-container {
+  width: 100%;
+}
+
+.card-form-container form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 1rem;
+  color: var(--text-dark);
+}
+
+.card-form-container input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(12, 44, 29, 0.2);
+  font-size: 1rem;
+}
+
+.card-form-container button[type='submit'] {
+  align-self: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--emerald-mid);
+  color: var(--cream);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.card-form-container button[type='submit']:hover,
+.card-form-container button[type='submit']:focus-visible {
+  background: var(--emerald-dark);
+  transform: translateY(-1px);
+}
+
+.thank-you-message {
+  margin: 0;
+  text-align: center;
+  font-size: 1rem;
+  color: var(--emerald-mid);
+  font-weight: 600;
+}
+
+.form-error-message {
+  color: #a23a3a;
 }
 
 .countdown-video-frame {

--- a/border-flip.html
+++ b/border-flip.html
@@ -57,13 +57,143 @@
     const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
 
-    const showCelebrationVideo = () => {
-      if (!countdownWrapper) {
+    const createFlipCardMarkup = () => `
+      <div class="flip-card" aria-live="polite">
+        <div class="flip-inner">
+          <div class="flip-front">
+            <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
+            <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
+            <div id="countdown" class="flip-countdown"></div>
+          </div>
+          <div class="flip-back">
+            <div id="backContent">
+              <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p><br>
+              <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
+            </div>
+            <div id="cantAttendFormContainer" class="card-form-container" style="display:none;">
+              <form action="https://script.google.com/macros/s/AKfycbw1oW3-NLd95psh53-YJFoUoa80b1jeyw9oEXX0TWffxMEyauwYvn6aVOn0UJdZgZF2IQ/exec" method="post">
+                <label>
+                  Name: <input type="text" name="name" required>
+                </label><br>
+                <label>
+                  Email: <input type="email" name="email" required>
+                </label><br><br>
+                <button type="submit">Send</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const attachFlipCardInteractions = () => {
+      if (!cardShell) {
         return;
       }
 
-      countdownWrapper.classList.add('has-video');
-      countdownWrapper.innerHTML = '';
+      const flipCard = cardShell.querySelector('.flip-card');
+      const countdownEl = cardShell.querySelector('#countdown');
+      const cantAttendBtn = cardShell.querySelector('#showCantAttendForm');
+      const backContent = cardShell.querySelector('#backContent');
+      const formContainer = cardShell.querySelector('#cantAttendFormContainer');
+      const form = formContainer?.querySelector('form');
+
+      if (flipCard) {
+        flipCard.addEventListener('click', (event) => {
+          const isInteractiveElement = (event.target instanceof HTMLElement) &&
+            (event.target.closest('form') || event.target.closest('.cant-attend-btn'));
+          if (isInteractiveElement) {
+            return;
+          }
+          flipCard.classList.toggle('flipped');
+        });
+      }
+
+      if (cantAttendBtn && backContent && formContainer) {
+        cantAttendBtn.addEventListener('click', () => {
+          backContent.setAttribute('hidden', '');
+          formContainer.style.display = 'block';
+        });
+      }
+
+      if (form && formContainer) {
+        const submitButton = form.querySelector('button[type="submit"]');
+        let isSubmitting = false;
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          if (isSubmitting) {
+            return;
+          }
+          isSubmitting = true;
+
+          if (submitButton instanceof HTMLButtonElement) {
+            submitButton.disabled = true;
+            submitButton.textContent = 'Sending...';
+          }
+
+          try {
+            const formData = new FormData(form);
+            await fetch(form.action, { method: 'POST', body: formData, mode: 'no-cors' });
+            formContainer.innerHTML = '<p class="thank-you-message">Thank you for letting us know. We will keep you updated!</p>';
+          } catch (error) {
+            let errorMessage = formContainer.querySelector('.form-error-message');
+            if (!errorMessage) {
+              errorMessage = document.createElement('p');
+              errorMessage.className = 'thank-you-message form-error-message';
+              formContainer.appendChild(errorMessage);
+            }
+            errorMessage.textContent = 'Submission failed. Please try again later.';
+
+            if (submitButton instanceof HTMLButtonElement) {
+              submitButton.disabled = false;
+              submitButton.textContent = 'Send';
+            }
+            isSubmitting = false;
+          }
+        });
+      }
+
+      if (countdownEl) {
+        const target = new Date('2026-09-12T00:00:00-07:00');
+        const updateCountdown = () => {
+          const diff = target.getTime() - Date.now();
+          if (diff <= 0) {
+            countdownEl.textContent = "It's today!";
+            return;
+          }
+          const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+          const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+          const minutes = Math.floor((diff / (1000 * 60)) % 60);
+          const seconds = Math.floor((diff / 1000) % 60);
+          countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+        };
+        updateCountdown();
+        window.setInterval(updateCountdown, 1000);
+      }
+    };
+
+    const showFlipCard = () => {
+      if (!cardShell) {
+        return;
+      }
+      cardShell.classList.remove('is-video');
+      cardShell.classList.add('has-flip');
+      cardShell.innerHTML = createFlipCardMarkup();
+      attachFlipCardInteractions();
+    };
+
+    const showCelebrationVideo = () => {
+      if (!cardShell) {
+        return;
+      }
+
+      cardShell.classList.remove('has-flip');
+      cardShell.classList.add('is-video');
+      cardShell.innerHTML = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'countdown-wrapper has-video';
 
       const videoFrame = document.createElement('div');
       videoFrame.className = 'countdown-video-frame';
@@ -72,16 +202,27 @@
       celebrationVideo.className = 'countdown-video';
       celebrationVideo.src = 'assets/video.mp4';
       celebrationVideo.autoplay = true;
-      celebrationVideo.loop = true;
       celebrationVideo.muted = true;
+      celebrationVideo.controls = true;
       celebrationVideo.setAttribute('playsinline', '');
 
-      videoFrame.appendChild(celebrationVideo);
-      countdownWrapper.appendChild(videoFrame);
+      celebrationVideo.addEventListener('ended', () => {
+        showFlipCard();
+      }, { once: true });
 
-      if (cardShell) {
-        cardShell.classList.add('is-video');
-      }
+      celebrationVideo.addEventListener('error', () => {
+        showFlipCard();
+      }, { once: true });
+
+      videoFrame.appendChild(celebrationVideo);
+      wrapper.appendChild(videoFrame);
+
+      const videoNote = document.createElement('p');
+      videoNote.className = 'countdown-note';
+      videoNote.textContent = 'A quick glimpse before the celebration details appear.';
+      wrapper.appendChild(videoNote);
+
+      cardShell.appendChild(wrapper);
     };
 
     if (countdownNumber) {
@@ -110,6 +251,8 @@
           countdownNumber.classList.remove('is-transitioning');
         }, 200);
       }, 1000);
+    } else {
+      showFlipCard();
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update the border flip page logic to show the celebration video first and reveal the invite flip card afterward
- restore the original invite flip card markup and interactions, including the RSVP fallback form
- reintroduce styling for the flip card, RSVP form, and supporting elements in the bordered gallery flip stylesheet

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd02514b70832e8bff092646909c12