### PR TITLE
Adjust border flip layout and sizing

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -169,8 +169,8 @@ body {
 }
 
 .card-shell.is-video {
-  width: min(620px, 100%);
-  padding: clamp(24px, 3.5vw, 44px);
+  width: min(700px, 100%);
+  padding: clamp(20px, 3vw, 40px);
 }
 
 .card-shell::before {
@@ -184,8 +184,8 @@ body {
 
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.35em;
-  font-size: clamp(0.7rem, 1.4vw, 0.9rem);
+  letter-spacing: 0.32em;
+  font-size: clamp(0.64rem, 1.2vw, 0.84rem);
   color: var(--text-muted);
   margin-bottom: clamp(10px, 1.4vw, 16px);
 }
@@ -197,22 +197,22 @@ body {
   border-radius: clamp(18px, 3vw, 30px);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
   border: 1.5px solid rgba(12, 44, 29, 0.12);
-  padding: clamp(28px, 5vw, 48px);
+  padding: clamp(26px, 4.6vw, 44px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: clamp(18px, 4vw, 32px);
+  gap: clamp(16px, 3.6vw, 28px);
 }
 
 .countdown-wrapper.has-video {
-  padding: clamp(18px, 4vw, 32px);
+  padding: clamp(14px, 3.5vw, 26px);
   background: rgba(255, 255, 255, 0.94);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
   border: 1.5px solid rgba(12, 44, 29, 0.12);
-  gap: clamp(12px, 3vw, 20px);
-  max-width: min(560px, 100%);
+  gap: clamp(10px, 2.5vw, 18px);
+  max-width: min(640px, 100%);
 }
 
 .countdown-wrapper.has-video::before {
@@ -223,15 +223,15 @@ body {
   background: rgba(255, 255, 255, 0.96);
   border: 1.5px solid rgba(12, 44, 29, 0.12);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
-  padding: clamp(32px, 5vw, 52px);
-  gap: clamp(14px, 4vw, 28px);
+  padding: clamp(30px, 4.8vw, 48px);
+  gap: clamp(12px, 3.8vw, 24px);
   align-items: center;
   max-width: min(520px, 100%);
 }
 
 .countdown-video-frame {
   width: 100%;
-  max-width: 540px;
+  max-width: 620px;
   border-radius: clamp(16px, 3vw, 28px);
   overflow: hidden;
   aspect-ratio: 16 / 9;
@@ -243,8 +243,8 @@ body {
 
 .countdown-number {
   font-family: var(--countdown-font);
-  font-size: clamp(3.2rem, 10vw, 6rem);
-  letter-spacing: 0.12em;
+  font-size: clamp(3rem, 9vw, 5.4rem);
+  letter-spacing: 0.1em;
   color: var(--text-dark);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
   transition: transform 0.4s ease, opacity 0.4s ease;
@@ -264,15 +264,15 @@ body {
 
 .countdown-note {
   margin: 0;
-  line-height: 1.6;
-  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  line-height: 1.5;
+  font-size: clamp(0.92rem, 2vw, 1.1rem);
   color: var(--text-muted);
 }
 
 .save-date-title {
   font-family: var(--countdown-font);
-  font-size: clamp(2rem, 6.6vw, 3.4rem);
-  letter-spacing: 0.15em;
+  font-size: clamp(1.8rem, 6vw, 3.05rem);
+  letter-spacing: 0.13em;
   text-transform: uppercase;
   color: var(--text-dark);
   margin: 0;
@@ -287,8 +287,8 @@ body {
 
 .save-date-date {
   margin: 0;
-  font-size: clamp(1.05rem, 2.6vw, 1.3rem);
-  letter-spacing: 0.1em;
+  font-size: clamp(0.95rem, 2.2vw, 1.18rem);
+  letter-spacing: 0.09em;
   text-transform: uppercase;
   color: rgba(12, 44, 29, 0.82);
   text-align: center;
@@ -302,8 +302,8 @@ body {
 }
 
 .save-date-date-location {
-  font-size: clamp(0.95rem, 2.2vw, 1.1rem);
-  letter-spacing: 0.18em;
+  font-size: clamp(0.85rem, 2vw, 1rem);
+  letter-spacing: 0.16em;
 }
 
 .save-date-countdown {
@@ -312,14 +312,14 @@ body {
 
 .countdown-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-  gap: clamp(12px, 3vw, 20px);
+  grid-template-columns: repeat(4, minmax(88px, 1fr));
+  gap: clamp(10px, 2.5vw, 18px);
 }
 
 .countdown-segment {
   background: rgba(12, 44, 29, 0.08);
   border-radius: clamp(14px, 3vw, 20px);
-  padding: clamp(14px, 3.4vw, 22px) clamp(12px, 3vw, 18px);
+  padding: clamp(12px, 3vw, 20px) clamp(10px, 2.6vw, 16px);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 14px 26px rgba(0, 0, 0, 0.14);
   display: flex;
   flex-direction: column;
@@ -330,16 +330,16 @@ body {
 
 .countdown-value {
   font-family: var(--countdown-font);
-  font-size: clamp(2.2rem, 8vw, 3.4rem);
-  letter-spacing: 0.12em;
+  font-size: clamp(1.9rem, 7vw, 3rem);
+  letter-spacing: 0.1em;
   color: var(--text-dark);
 }
 
 .countdown-label {
-  margin-top: clamp(6px, 1.2vw, 10px);
+  margin-top: clamp(4px, 1vw, 8px);
   text-transform: uppercase;
-  letter-spacing: 0.32em;
-  font-size: clamp(0.62rem, 1.6vw, 0.78rem);
+  letter-spacing: 0.28em;
+  font-size: clamp(0.58rem, 1.4vw, 0.72rem);
   color: var(--text-muted);
 }
 
@@ -388,12 +388,13 @@ body {
   }
 
   .save-date-title {
-    font-size: clamp(1.8rem, 7vw, 3rem);
-    letter-spacing: 0.12em;
+    font-size: clamp(1.6rem, 6.4vw, 2.6rem);
+    letter-spacing: 0.11em;
   }
 
   .save-date-date {
-    letter-spacing: 0.12em;
+    font-size: clamp(0.9rem, 3.6vw, 1.08rem);
+    letter-spacing: 0.085em;
   }
 }
 
@@ -417,18 +418,29 @@ body {
   }
 
   .countdown-grid {
-    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    grid-template-columns: repeat(4, minmax(64px, 1fr));
+    gap: clamp(8px, 3.6vw, 14px);
   }
 
   .save-date-title {
+    font-size: clamp(1.4rem, 8vw, 2.2rem);
     letter-spacing: 0.1em;
   }
 
   .save-date-date {
-    font-size: clamp(0.95rem, 4.5vw, 1.2rem);
+    font-size: clamp(0.82rem, 4vw, 1.02rem);
   }
 
   .save-date-date-location {
-    letter-spacing: 0.16em;
+    letter-spacing: 0.14em;
+  }
+
+  .countdown-value {
+    font-size: clamp(1.6rem, 9vw, 2.4rem);
+  }
+
+  .countdown-label {
+    letter-spacing: 0.24em;
+    font-size: clamp(0.54rem, 2.6vw, 0.66rem);
   }
 }


### PR DESCRIPTION
## Summary
- widen the celebration video frame and reduce surrounding padding so it fills more of the border flip card while maintaining its aspect ratio
- tighten typography and spacing on the invite state so copy fits comfortably within the frame
- force the countdown segments into a single row with scaled-down values and labels for better balance across viewports

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd75ef575c832eb86bf3e0e229cab3