### PR TITLE
Remove countdown timer from border flip details

### DIFF
--- a/border-flip.html
+++ b/border-flip.html
@@ -81,42 +81,6 @@
       dateLine.innerHTML = '<span class="save-date-date-main">September 12, 2026</span>' +
         '<span class="save-date-date-location">Portola, California</span>';
 
-      const countdownContainer = document.createElement('div');
-      countdownContainer.className = 'save-date-countdown';
-      countdownContainer.setAttribute('aria-live', 'polite');
-      countdownContainer.setAttribute('role', 'timer');
-
-      const countdownGrid = document.createElement('div');
-      countdownGrid.className = 'countdown-grid';
-      countdownContainer.appendChild(countdownGrid);
-
-      const countdownValues = {};
-      const countdownSegments = [
-        ['days', 'Days'],
-        ['hours', 'Hours'],
-        ['minutes', 'Minutes'],
-        ['seconds', 'Seconds'],
-      ];
-
-      countdownSegments.forEach(([unit, label]) => {
-        const segment = document.createElement('div');
-        segment.className = 'countdown-segment';
-
-        const value = document.createElement('div');
-        value.className = 'countdown-value';
-        value.textContent = '00';
-        value.setAttribute('data-unit', unit);
-
-        const unitLabel = document.createElement('div');
-        unitLabel.className = 'countdown-label';
-        unitLabel.textContent = label;
-
-        segment.appendChild(value);
-        segment.appendChild(unitLabel);
-        countdownGrid.appendChild(segment);
-        countdownValues[unit] = value;
-      });
-
       const note = document.createElement('p');
       note.className = 'countdown-note save-date-note';
       note.textContent = "Formal invitation to follow. We can't wait to celebrate with you!";
@@ -124,67 +88,11 @@
       countdownWrapper.appendChild(eyebrow);
       countdownWrapper.appendChild(title);
       countdownWrapper.appendChild(dateLine);
-      countdownWrapper.appendChild(countdownContainer);
       countdownWrapper.appendChild(note);
 
       if (cardShell) {
         cardShell.classList.remove('is-video');
         cardShell.classList.add('is-details');
-      }
-
-      const eventDate = new Date('2026-09-12T16:00:00-07:00');
-
-      const formatNumber = (value) => {
-        const stringValue = String(Math.max(0, value));
-        return stringValue.padStart(2, '0');
-      };
-
-      const updateCountdown = () => {
-        const now = new Date();
-        const totalMilliseconds = eventDate.getTime() - now.getTime();
-
-        if (totalMilliseconds <= 0) {
-          countdownValues.days.textContent = '00';
-          countdownValues.hours.textContent = '00';
-          countdownValues.minutes.textContent = '00';
-          countdownValues.seconds.textContent = '00';
-          note.textContent = 'Today is the day—see you soon!';
-          countdownContainer.setAttribute('aria-label', 'Countdown complete');
-          return false;
-        }
-
-        const totalSeconds = Math.floor(totalMilliseconds / 1000);
-        const secondsInDay = 60 * 60 * 24;
-        const secondsInHour = 60 * 60;
-        const secondsInMinute = 60;
-
-        const days = Math.floor(totalSeconds / secondsInDay);
-        const hours = Math.floor((totalSeconds % secondsInDay) / secondsInHour);
-        const minutes = Math.floor((totalSeconds % secondsInHour) / secondsInMinute);
-        const seconds = totalSeconds % secondsInMinute;
-
-        countdownValues.days.textContent = formatNumber(days);
-        countdownValues.hours.textContent = formatNumber(hours);
-        countdownValues.minutes.textContent = formatNumber(minutes);
-        countdownValues.seconds.textContent = formatNumber(seconds);
-
-        countdownContainer.setAttribute(
-          'aria-label',
-          `${days} days, ${hours} hours, ${minutes} minutes, and ${seconds} seconds until the celebration`
-        );
-
-        return true;
-      };
-
-      const hasTimeRemaining = updateCountdown();
-
-      if (hasTimeRemaining) {
-        const eventCountdownInterval = window.setInterval(() => {
-          const stillCounting = updateCountdown();
-          if (!stillCounting) {
-            window.clearInterval(eventCountdownInterval);
-          }
-        }, 1000);
       }
     };
 


### PR DESCRIPTION
## Summary
- remove the countdown timer UI from the border flip details state
- leave only the save the date messaging once the video finishes

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd7d418d78832e94ea06af39206f50