### PR TITLE
Adjust save the date text positioning

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -226,6 +226,8 @@ body {
   padding: clamp(30px, 4.8vw, 48px);
   gap: clamp(12px, 3.8vw, 24px);
   align-items: center;
+  justify-content: flex-start;
+  padding-top: clamp(24px, 4.2vw, 44px);
   max-width: min(520px, 100%);
 }
 


### PR DESCRIPTION
## Summary
- move the Save the Date detail state content toward the top of the card for improved balance by adjusting flex alignment and padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd7e787c48832e98012dfd0fc30c55