### PR TITLE
Update border page video and invite details

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -151,8 +151,19 @@ body {
 }
 
 .countdown-wrapper.has-video {
-  gap: clamp(12px, 3vw, 20px);
-  padding: clamp(18px, 4vw, 32px);
+  gap: clamp(10px, 2.6vw, 18px);
+  padding: clamp(16px, 3.6vw, 30px);
+  max-width: min(640px, 100%);
+}
+
+.countdown-wrapper.has-details {
+  background: rgba(255, 255, 255, 0.96);
+  border: 1.5px solid rgba(12, 44, 29, 0.12);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+  padding: clamp(30px, 4.8vw, 48px);
+  gap: clamp(12px, 3.8vw, 24px);
+  align-items: center;
+  max-width: min(520px, 100%);
 }
 
 .countdown-number {
@@ -178,8 +189,8 @@ body {
 
 .countdown-video-frame {
   width: 100%;
-  max-width: 480px;
-  border-radius: calc(var(--card-radius) - clamp(6px, 1.5vw, 12px));
+  max-width: 620px;
+  border-radius: clamp(16px, 3vw, 28px);
   overflow: hidden;
   aspect-ratio: 16 / 9;
   background: #000;
@@ -192,6 +203,65 @@ body {
   height: 100%;
   object-fit: contain;
   display: block;
+}
+
+.video-hashtag {
+  font-size: clamp(0.8rem, 1.8vw, 1rem);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(12, 44, 29, 0.72);
+  margin: 0;
+}
+
+.save-date-title {
+  font-family: var(--countdown-font);
+  font-size: clamp(1.8rem, 6vw, 3.05rem);
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--text-dark);
+  margin: 0;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.save-date-title span {
+  display: block;
+  margin: 0;
+}
+
+.save-date-title .save-date-name {
+  letter-spacing: 0.18em;
+}
+
+.save-date-title .save-date-amp {
+  font-size: clamp(2.1rem, 7vw, 3.5rem);
+  letter-spacing: 0.38em;
+  margin-block: clamp(4px, 1vw, 10px);
+}
+
+.save-date-date {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.2vw, 1.18rem);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: rgba(12, 44, 29, 0.82);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 1vw, 8px);
+}
+
+.save-date-date span {
+  display: block;
+}
+
+.save-date-date-location {
+  font-size: clamp(0.85rem, 2vw, 1rem);
+  letter-spacing: 0.16em;
+}
+
+.save-date-note {
+  font-size: clamp(0.92rem, 2vw, 1.1rem);
 }
 
 .flip-card {

--- a/border.html
+++ b/border.html
@@ -45,130 +45,44 @@
     });
 
     const cardShell = document.getElementById('cardShell');
-    const countdownWrapper = cardShell?.querySelector('.countdown-wrapper');
+    const initialCountdownWrapper = cardShell?.querySelector('.countdown-wrapper');
     const countdownNumber = document.getElementById('countdownNumber');
-    const countdownNote = countdownWrapper?.querySelector('.countdown-note');
+    const countdownNote = initialCountdownWrapper?.querySelector('.countdown-note');
     const countdownStart = 10;
     let currentValue = countdownStart;
 
-    const createFlipCardMarkup = () => {
-      return `
-        <div class="flip-card" aria-live="polite">
-          <div class="flip-inner">
-            <div class="flip-front">
-              <h1 class="wedding-names">Lorraine<br>&amp;<br>Christopher</h1>
-              <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
-              <div id="countdown" class="flip-countdown"></div>
-            </div>
-            <div class="flip-back">
-              <div id="backContent">
-                <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p><br>
-                <button id="showCantAttendForm" class="cant-attend-btn">Can't Attend</button>
-              </div>
-              <div id="cantAttendFormContainer" class="card-form-container" style="display:none;">
-                <form action="https://script.google.com/macros/s/AKfycbw1oW3-NLd95psh53-YJFoUoa80b1jeyw9oEXX0TWffxMEyauwYvn6aVOn0UJdZgZF2IQ/exec" method="post">
-                  <label>
-                    Name: <input type="text" name="name" required>
-                  </label><br>
-                  <label>
-                    Email: <input type="email" name="email" required>
-                  </label><br><br>
-                  <button type="submit">Send</button>
-                </form>
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-    };
-
-    const attachFlipCardInteractions = () => {
-      const flipCard = cardShell?.querySelector('.flip-card');
-      const countdownEl = cardShell?.querySelector('#countdown');
-      const cantAttendBtn = cardShell?.querySelector('#showCantAttendForm');
-      const backContent = cardShell?.querySelector('#backContent');
-      const formContainer = cardShell?.querySelector('#cantAttendFormContainer');
-      const form = formContainer?.querySelector('form');
-
-      if (flipCard) {
-        flipCard.addEventListener('click', (event) => {
-          const isInteractiveElement = (event.target instanceof HTMLElement) &&
-            (event.target.closest('form') || event.target.closest('.cant-attend-btn'));
-          if (isInteractiveElement) {
-            return;
-          }
-          flipCard.classList.toggle('flipped');
-        });
-      }
-
-      if (cantAttendBtn && backContent && formContainer) {
-        cantAttendBtn.addEventListener('click', () => {
-          backContent.setAttribute('hidden', '');
-          formContainer.style.display = 'block';
-        });
-      }
-
-      if (form && formContainer) {
-        const submitButton = form.querySelector('button[type="submit"]');
-        let isSubmitting = false;
-
-        form.addEventListener('submit', async (event) => {
-          event.preventDefault();
-          if (isSubmitting) {
-            return;
-          }
-          isSubmitting = true;
-
-          if (submitButton instanceof HTMLButtonElement) {
-            submitButton.disabled = true;
-            submitButton.textContent = 'Sending...';
-          }
-
-          try {
-            const formData = new FormData(form);
-            await fetch(form.action, { method: 'POST', body: formData, mode: 'no-cors' });
-            formContainer.innerHTML = '<p class="thank-you-message">Thank you for letting us know. We will keep you updated!</p>';
-          } catch (error) {
-            let errorMessage = formContainer.querySelector('.form-error-message');
-            if (!errorMessage) {
-              errorMessage = document.createElement('p');
-              errorMessage.className = 'thank-you-message form-error-message';
-              formContainer.appendChild(errorMessage);
-            }
-            errorMessage.textContent = 'Submission failed. Please try again later.';
-
-            if (submitButton instanceof HTMLButtonElement) {
-              submitButton.disabled = false;
-              submitButton.textContent = 'Send';
-            }
-            isSubmitting = false;
-          }
-        });
-      }
-
-      if (countdownEl) {
-        const target = new Date('2026-09-12T00:00:00-07:00');
-        const updateCountdown = () => {
-          const diff = target.getTime() - Date.now();
-          if (diff <= 0) {
-            countdownEl.textContent = "It's today!";
-            return;
-          }
-          const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-          const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-          const minutes = Math.floor((diff / (1000 * 60)) % 60);
-          const seconds = Math.floor((diff / 1000) % 60);
-          countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-        };
-        updateCountdown();
-        window.setInterval(updateCountdown, 1000);
-      }
-    };
-
-    const showFlipCard = () => {
+    const showSaveTheDateDetails = () => {
       if (!cardShell) return;
-      cardShell.innerHTML = createFlipCardMarkup();
-      attachFlipCardInteractions();
+      cardShell.innerHTML = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'countdown-wrapper has-details';
+
+      const eyebrow = document.createElement('p');
+      eyebrow.className = 'eyebrow';
+      eyebrow.textContent = 'Save the Date';
+
+      const title = document.createElement('h1');
+      title.className = 'save-date-title';
+      title.innerHTML = '<span class="save-date-name">Lorraine</span>' +
+        '<span class="save-date-amp">&amp;</span>' +
+        '<span class="save-date-name">Christopher</span>';
+
+      const dateLine = document.createElement('p');
+      dateLine.className = 'save-date-date';
+      dateLine.innerHTML = '<span class="save-date-date-main">September 12, 2026</span>' +
+        '<span class="save-date-date-location">Portola, California</span>';
+
+      const note = document.createElement('p');
+      note.className = 'countdown-note save-date-note';
+      note.textContent = 'Formal invite to follow';
+
+      wrapper.appendChild(eyebrow);
+      wrapper.appendChild(title);
+      wrapper.appendChild(dateLine);
+      wrapper.appendChild(note);
+
+      cardShell.appendChild(wrapper);
     };
 
     const showCelebrationVideo = () => {
@@ -178,6 +92,10 @@
       const wrapper = document.createElement('div');
       wrapper.className = 'countdown-wrapper has-video';
 
+      const videoHashtag = document.createElement('p');
+      videoHashtag.className = 'video-hashtag';
+      videoHashtag.textContent = '#BECOMINGCUMMINGS';
+
       const videoFrame = document.createElement('div');
       videoFrame.className = 'countdown-video-frame';
 
@@ -186,25 +104,25 @@
       celebrationVideo.src = 'assets/video.mp4';
       celebrationVideo.autoplay = true;
       celebrationVideo.muted = true;
-      celebrationVideo.playsInline = true;
-      celebrationVideo.controls = true;
+      celebrationVideo.setAttribute('playsinline', '');
 
       celebrationVideo.addEventListener('ended', () => {
-        showFlipCard();
+        showSaveTheDateDetails();
+      }, { once: true });
+
+      celebrationVideo.addEventListener('error', () => {
+        showSaveTheDateDetails();
       }, { once: true });
 
       videoFrame.appendChild(celebrationVideo);
-      wrapper.appendChild(videoFrame);
 
-      const videoNote = document.createElement('p');
-      videoNote.className = 'countdown-note';
-      videoNote.textContent = 'A quick glimpse before the celebration details appear.';
-      wrapper.appendChild(videoNote);
+      wrapper.appendChild(videoHashtag);
+      wrapper.appendChild(videoFrame);
 
       cardShell.appendChild(wrapper);
     };
 
-    if (countdownNumber && countdownWrapper) {
+    if (countdownNumber && initialCountdownWrapper) {
       countdownNumber.textContent = String(currentValue);
       const countdownInterval = window.setInterval(() => {
         currentValue -= 1;
@@ -230,7 +148,7 @@
         }, 200);
       }, 1000);
     } else {
-      showFlipCard();
+      showCelebrationVideo();
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- enlarge the video presentation on the bordered page and add support styles for the new layout
- replace the flip-card interaction with a simple countdown-to-video flow that ends with the updated save-the-date details

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd7f037558832ea70d487aba098227