### PR TITLE
Refine border flip countdown display

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -245,17 +245,16 @@ body {
 
 .countdown-number {
   font-family: var(--countdown-font);
-  font-size: clamp(3rem, 9vw, 5.4rem);
+  font-size: clamp(4rem, 12vw, 6.8rem);
   letter-spacing: 0.1em;
-  color: var(--text-dark);
+  color: var(--emerald-mid);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
   font-variant-numeric: tabular-nums;
   margin-left: -0.12em;
-  transition: transform 0.4s ease, opacity 0.4s ease;
+  transition: transform 0.4s ease;
 }
 
 .countdown-number.is-transitioning {
-  opacity: 0.6;
   transform: scale(0.9);
 }
 

--- a/border-flip.html
+++ b/border-flip.html
@@ -22,9 +22,7 @@
     <main class="content-card">
       <div class="card-shell">
         <div class="countdown-wrapper" aria-live="polite">
-          <p class="eyebrow">Celebration Countdown</p>
           <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
-          <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
@@ -54,7 +52,6 @@
     const cardShell = countdownWrapper ? countdownWrapper.closest('.card-shell') : null;
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
-    const countdownNote = document.querySelector('.countdown-note');
     let currentValue = countdownStart;
 
     const showSaveTheDateDetails = () => {
@@ -148,9 +145,6 @@
           countdownNumber.textContent = '0';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
-          if (countdownNote) {
-            countdownNote.textContent = 'It\'s time to celebrate!';
-          }
           window.setTimeout(() => {
             showCelebrationVideo();
           }, 400);


### PR DESCRIPTION
## Summary
- remove the extra eyebrow and note text so the border flip countdown only shows the number
- enlarge the countdown digits and lock them to the theme’s emerald color without fading during transitions

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cd80963d8c832e8b6a4558c63252ae