### PR TITLE
Ensure border flip card overlays gallery

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -151,6 +151,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 2;
 }
 
 .card-shell {
@@ -166,6 +167,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.border-cell {
+  z-index: 1;
 }
 
 .card-shell.is-video {


### PR DESCRIPTION
## Summary
- raise the stacking order of the central content card so it stays above the gallery border images when details are revealed
- ensure border image tiles render beneath the card for consistent top and bottom overlap

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd811edf18832eb26ad9d455f87f62