### PR TITLE
Restore border flip countdown prompts

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -208,7 +208,7 @@ body {
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: clamp(16px, 3.6vw, 28px);
+  gap: clamp(14px, 3.2vw, 26px);
 }
 
 .countdown-wrapper.has-video {
@@ -250,7 +250,7 @@ body {
 
 .countdown-number {
   font-family: var(--countdown-font);
-  font-size: clamp(4rem, 12vw, 6.8rem);
+  font-size: clamp(5.5rem, 18vw, 11rem);
   letter-spacing: 0.1em;
   color: var(--emerald-mid);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
@@ -261,6 +261,18 @@ body {
 
 .countdown-number.is-transitioning {
   transform: scale(0.9);
+}
+
+.countdown-prompt {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: clamp(0.74rem, 2.4vw, 1.05rem);
+  color: rgba(12, 44, 29, 0.72);
+}
+
+.countdown-prompt--top {
+  order: -1;
 }
 
 .countdown-video {

--- a/border-flip.html
+++ b/border-flip.html
@@ -22,7 +22,9 @@
     <main class="content-card">
       <div class="card-shell">
         <div class="countdown-wrapper" aria-live="polite">
+          <p class="countdown-prompt countdown-prompt--top">get ready</p>
           <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <p class="countdown-prompt countdown-prompt--bottom">to party</p>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- restore the border flip countdown layout to include “get ready” and “to party” prompts framing the numerals
- enlarge the countdown numerals for the introductory sequence while keeping later transitions intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd834c3fb4832e868e458a9bb3644e