### PR TITLE
Animate intro card reveal after video

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -118,7 +118,6 @@ html, body {
   justify-content: center;
   height: 100%;
   max-height: 100%;
-  pointer-events: auto;
 }
 
 .intro-card-shell {
@@ -548,11 +547,18 @@ html, body {
 .intro-card-container {
   position: relative;
   z-index: 1;
-  opacity: 1;
+  pointer-events: none;
+  opacity: 0;
+  transform: perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-4deg) scale(0.86);
+  transform-origin: center;
+  transform-style: preserve-3d;
+  will-change: transform, opacity;
 }
 
 .intro-card-container.visible {
+  pointer-events: auto;
   opacity: 1;
+  animation: card-reveal-spin 1.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .intro-card-container .flip-card {
@@ -561,6 +567,17 @@ html, body {
 
 .intro-card-container.visible .flip-card {
   animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro-card-container {
+    transform: none;
+  }
+
+  .intro-card-container.visible {
+    animation: none !important;
+    opacity: 1;
+  }
 }
 
 .flip-card {
@@ -711,6 +728,21 @@ button.loading::after {
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
 }
+@keyframes card-reveal-spin {
+  0% {
+    opacity: 0;
+    transform: perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-6deg) scale(0.78);
+  }
+  55% {
+    opacity: 1;
+    transform: perspective(1400px) rotateX(-6deg) rotateY(8deg) rotateZ(3deg) scale(1.04);
+  }
+  100% {
+    opacity: 1;
+    transform: perspective(1400px) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1);
+  }
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);

--- a/assets/js/save-the-date.js
+++ b/assets/js/save-the-date.js
@@ -84,10 +84,34 @@ document.addEventListener('DOMContentLoaded', () => {
     osc.stop(now + 0.3);
   };
 
-  if (video) {
-    video.addEventListener('ended', () => {
-      introCard?.classList.add('visible');
+  const revealIntroCard = () => {
+    if (!introCard) return;
+    requestAnimationFrame(() => {
+      introCard.classList.add('visible');
     });
+  };
+
+  if (video && introCard) {
+    introCard.classList.remove('visible');
+    const showAfterVideo = () => {
+      revealIntroCard();
+    };
+    const fallbackDelay = Number.isFinite(video.duration) && video.duration > 0
+      ? Math.ceil(video.duration * 1000) + 2000
+      : 60000;
+    const fallbackTimer = window.setTimeout(showAfterVideo, fallbackDelay);
+    const handleAndClear = () => {
+      window.clearTimeout(fallbackTimer);
+      showAfterVideo();
+    };
+    ['ended', 'error', 'abort'].forEach((eventName) => {
+      video.addEventListener(eventName, handleAndClear, { once: true });
+    });
+    if (video.ended) {
+      handleAndClear();
+    }
+  } else if (introCard && !introCard.classList.contains('visible')) {
+    revealIntroCard();
   }
 
   if (preCountdown && video) {


### PR DESCRIPTION
## Summary
- add a 3D spin-in animation to the save-the-date intro card when it becomes visible
- gate the intro card visibility so it appears after the background video finishes or fails, with a long fallback timer
- respect reduced-motion preferences to keep the card static when animations are disabled

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd83d82304832eb813b0e67f889f78