### PR TITLE
Add interactive countdown overlay with synced border reveals

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -53,12 +53,11 @@ body {
   overflow: hidden;
   isolation: isolate;
   border-radius: clamp(16px, 3vw, 28px);
+  opacity: 0;
 }
 
-.border-cell.is-ready {
-  opacity: 0;
-  animation: border-cell-in 1.6s ease-out forwards;
-  animation-delay: var(--border-cell-delay, 0s);
+.border-cell.is-visible {
+  animation: border-cell-in var(--border-cell-duration, 1.8s) ease-out forwards;
 }
 
 @keyframes border-cell-in {
@@ -396,10 +395,102 @@ body {
   color: rgba(12, 44, 29, 0.68);
 }
 
+.countdown-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(3, 40, 28, 0.9);
+  color: var(--cream);
+  z-index: 5;
+  font-family: var(--countdown-font);
+  font-size: clamp(2.6rem, 9vw, 6rem);
+  letter-spacing: 0.2em;
+  transition: opacity 0.6s ease;
+  overflow: hidden;
+}
+
+.countdown-overlay.start-prompt {
+  cursor: pointer;
+}
+
+.countdown-overlay:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 6px;
+}
+
+.countdown-overlay-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: clamp(48px, 14vh, 160px) clamp(24px, 12vw, 80px);
+  gap: clamp(24px, 8vh, 48px);
+  pointer-events: none;
+}
+
+.countdown-overlay-line {
+  display: block;
+  width: 100%;
+  text-align: center;
+  text-transform: uppercase;
+  text-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+}
+
+.countdown-overlay-line--top {
+  align-self: flex-start;
+}
+
+.countdown-overlay-line--bottom {
+  align-self: flex-end;
+}
+
+.countdown-overlay::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(140px, 32vw, 360px);
+  height: clamp(140px, 32vw, 360px);
+  border-radius: clamp(18px, 3vw, 32px);
+  border: 2px solid rgba(255, 255, 255, 0.28);
+  background: rgba(0, 0, 0, 0.35);
+  box-shadow: 0 24px 40px rgba(0, 0, 0, 0.48);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.86);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.countdown-overlay.is-counting {
+  background: transparent;
+  pointer-events: none;
+}
+
+.countdown-overlay.is-counting::before {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.countdown-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (max-width: 520px) {
+  .countdown-overlay-line {
+    font-size: clamp(2.2rem, 12vw, 4.4rem);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .border-cell.is-ready {
-    animation: none;
-    opacity: 1;
+  .border-cell {
+    animation: none !important;
+    opacity: 1 !important;
   }
 }
 

--- a/border-flip.html
+++ b/border-flip.html
@@ -10,6 +10,18 @@
   <link rel="stylesheet" href="assets/css/bordered-gallery-flip.css">
 </head>
 <body>
+  <div
+    class="countdown-overlay start-prompt"
+    id="startOverlay"
+    role="button"
+    tabindex="0"
+    aria-label="Start the countdown"
+  >
+    <div class="countdown-overlay-content">
+      <span class="countdown-overlay-line countdown-overlay-line--top">get ready</span>
+      <span class="countdown-overlay-line countdown-overlay-line--bottom">to party</span>
+    </div>
+  </div>
   <div class="page-border">
     <div class="border-cell top-left"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
     <div class="border-cell top-left-center"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
@@ -39,22 +51,104 @@
   </div>
 
   <script>
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = AudioContext ? new AudioContext() : null;
+    const playBeat = () => {
+      if (!audioCtx) return;
+      if (audioCtx.state === 'suspended') {
+        audioCtx.resume().catch(() => {});
+      }
+
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(82, audioCtx.currentTime);
+      osc.connect(gain);
+      gain.connect(audioCtx.destination);
+
+      const now = audioCtx.currentTime;
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(1.3, now + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.34);
+      osc.start(now);
+      osc.stop(now + 0.34);
+    };
+
     const borderCells = Array.from(document.querySelectorAll('.border-cell'));
-    borderCells.forEach((cell, index) => {
-      cell.style.setProperty('--border-cell-delay', `${index * 0.35}s`);
-    });
-
-    requestAnimationFrame(() => {
-      borderCells.forEach((cell) => {
-        cell.classList.add('is-ready');
-      });
-    });
-
     const countdownWrapper = document.querySelector('.countdown-wrapper');
     const cardShell = countdownWrapper ? countdownWrapper.closest('.card-shell') : null;
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownStart = 10;
     let currentValue = countdownStart;
+    const startOverlay = document.getElementById('startOverlay');
+    let countdownInterval = null;
+    let revealIndex = 0;
+
+    const totalCountdownSteps = countdownStart + 1;
+    const totalBorderCells = borderCells.length;
+    const baseRevealCount = totalCountdownSteps > 0 ? Math.floor(totalBorderCells / totalCountdownSteps) : 0;
+    const extraRevealSteps = totalCountdownSteps > 0 ? totalBorderCells % totalCountdownSteps : 0;
+    const revealSchedule = Array.from({ length: totalCountdownSteps }, () => baseRevealCount);
+    for (let step = 0; step < extraRevealSteps; step += 1) {
+      const index = revealSchedule.length - 1 - step;
+      if (index >= 0) {
+        revealSchedule[index] += 1;
+      }
+    }
+
+    const revealNextCells = (count = 1) => {
+      for (let i = 0; i < count; i += 1) {
+        if (revealIndex >= totalBorderCells) {
+          return;
+        }
+
+        const cell = borderCells[revealIndex];
+        if (cell) {
+          const progress = totalBorderCells > 1 ? revealIndex / (totalBorderCells - 1) : 1;
+          const baseDuration = 1.8;
+          const minDuration = 1.05;
+          const duration = Math.max(minDuration, baseDuration - (baseDuration - minDuration) * progress);
+          cell.style.setProperty('--border-cell-duration', `${duration.toFixed(2)}s`);
+          requestAnimationFrame(() => {
+            cell.classList.add('is-visible');
+          });
+        }
+
+        revealIndex += 1;
+      }
+    };
+
+    let revealStep = 0;
+    const applyRevealSchedule = () => {
+      const count = revealSchedule[revealStep] ?? 0;
+      if (count > 0) {
+        revealNextCells(count);
+      }
+      revealStep += 1;
+    };
+
+    const updateCountdownDisplay = (value) => {
+      if (!countdownNumber) return;
+
+      countdownNumber.textContent = String(value);
+      countdownNumber.setAttribute(
+        'aria-label',
+        value <= 0 ? 'Countdown finished' : `Countdown at ${value}`
+      );
+    };
+
+    const finishCountdown = () => {
+      window.clearInterval(countdownInterval);
+      countdownInterval = null;
+      window.setTimeout(() => {
+        startOverlay?.classList.add('hidden');
+        showCelebrationVideo();
+      }, 500);
+    };
+
+    if (countdownNumber) {
+      updateCountdownDisplay(currentValue);
+    }
 
     const showSaveTheDateDetails = () => {
       if (!countdownWrapper) {
@@ -136,28 +230,80 @@
       }
     };
 
-    if (countdownNumber) {
-      countdownNumber.textContent = String(currentValue);
+    const startCountdown = () => {
+      if (!countdownNumber || countdownInterval !== null) {
+        return;
+      }
 
-      const countdownInterval = window.setInterval(() => {
+      startOverlay?.classList.remove('start-prompt');
+      startOverlay?.classList.add('is-counting');
+      startOverlay?.setAttribute('aria-hidden', 'true');
+      startOverlay?.setAttribute('tabindex', '-1');
+
+      updateCountdownDisplay(currentValue);
+      playBeat();
+      applyRevealSchedule();
+
+      countdownInterval = window.setInterval(() => {
         currentValue -= 1;
+        if (!countdownNumber) {
+          return;
+        }
+
         countdownNumber.classList.add('is-transitioning');
 
-        if (currentValue <= 0) {
-          countdownNumber.textContent = '0';
-          countdownNumber.setAttribute('aria-label', 'Countdown finished');
-          window.clearInterval(countdownInterval);
-          window.setTimeout(() => {
-            showCelebrationVideo();
-          }, 400);
-        } else {
-          countdownNumber.textContent = String(currentValue);
-          countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
-        }
+        const value = Math.max(0, currentValue);
+        updateCountdownDisplay(value);
+        playBeat();
+        applyRevealSchedule();
 
         window.setTimeout(() => {
           countdownNumber.classList.remove('is-transitioning');
-        }, 200);
+        }, 220);
+
+        if (value <= 0) {
+          finishCountdown();
+        }
+      }, 1000);
+    };
+
+    const handleOverlayKeydown = (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        startCountdown();
+      }
+    };
+
+    if (startOverlay) {
+      startOverlay.addEventListener('click', () => {
+        audioCtx?.resume().catch(() => {});
+        startCountdown();
+      });
+      startOverlay.addEventListener('keydown', handleOverlayKeydown);
+    } else if (countdownNumber) {
+      updateCountdownDisplay(currentValue);
+      playBeat();
+      applyRevealSchedule();
+
+      countdownInterval = window.setInterval(() => {
+        currentValue -= 1;
+        if (!countdownNumber) {
+          return;
+        }
+
+        countdownNumber.classList.add('is-transitioning');
+        const value = Math.max(0, currentValue);
+        updateCountdownDisplay(value);
+        playBeat();
+        applyRevealSchedule();
+
+        window.setTimeout(() => {
+          countdownNumber.classList.remove('is-transitioning');
+        }, 220);
+
+        if (value <= 0) {
+          finishCountdown();
+        }
       }, 1000);
     }
   </script>


### PR DESCRIPTION
## Summary
- add a start overlay to the border flip experience that kicks off the countdown with audible ticks
- reveal border cells more gradually in sync with each countdown number before playing the celebration video
- style the new overlay prompt while honoring reduced-motion preferences

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8473e2e0832e8bad149ece7e38b6