### PR TITLE
Align border flip countdown with border layout

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -202,13 +202,13 @@ body {
   border-radius: clamp(18px, 3vw, 30px);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
   border: 1.5px solid rgba(12, 44, 29, 0.12);
-  padding: clamp(26px, 4.6vw, 44px);
+  padding: clamp(28px, 5vw, 48px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: clamp(14px, 3.2vw, 26px);
+  gap: clamp(18px, 4vw, 30px);
 }
 
 .countdown-wrapper.has-video {
@@ -250,29 +250,16 @@ body {
 
 .countdown-number {
   font-family: var(--countdown-font);
-  font-size: clamp(5.5rem, 18vw, 11rem);
-  letter-spacing: 0.1em;
-  color: var(--emerald-mid);
-  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-  font-variant-numeric: tabular-nums;
-  margin-left: -0.12em;
-  transition: transform 0.4s ease;
+  font-size: clamp(3rem, 10vw, 6rem);
+  letter-spacing: 0.12em;
+  color: var(--text-dark);
+  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
 .countdown-number.is-transitioning {
+  opacity: 0.6;
   transform: scale(0.9);
-}
-
-.countdown-prompt {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.35em;
-  font-size: clamp(0.74rem, 2.4vw, 1.05rem);
-  color: rgba(12, 44, 29, 0.72);
-}
-
-.countdown-prompt--top {
-  order: -1;
 }
 
 .countdown-video {
@@ -284,8 +271,8 @@ body {
 
 .countdown-note {
   margin: 0;
-  line-height: 1.5;
-  font-size: clamp(0.92rem, 2vw, 1.1rem);
+  line-height: 1.6;
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
   color: var(--text-muted);
 }
 

--- a/border-flip.html
+++ b/border-flip.html
@@ -20,11 +20,11 @@
     <div class="border-cell mid-right-upper"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
 
     <main class="content-card">
-      <div class="card-shell">
+      <div class="card-shell" id="cardShell">
         <div class="countdown-wrapper" aria-live="polite">
-          <p class="countdown-prompt countdown-prompt--top">get ready</p>
+          <p class="eyebrow">Celebration Countdown</p>
           <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
-          <p class="countdown-prompt countdown-prompt--bottom">to party</p>
+          <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
@@ -50,20 +50,22 @@
       });
     });
 
-    const countdownWrapper = document.querySelector('.countdown-wrapper');
-    const cardShell = countdownWrapper ? countdownWrapper.closest('.card-shell') : null;
+    const cardShell = document.getElementById('cardShell');
+    const initialCountdownWrapper = cardShell ? cardShell.querySelector('.countdown-wrapper') : null;
     const countdownNumber = document.getElementById('countdownNumber');
+    const countdownNote = initialCountdownWrapper ? initialCountdownWrapper.querySelector('.countdown-note') : null;
     const countdownStart = 10;
     let currentValue = countdownStart;
 
     const showSaveTheDateDetails = () => {
-      if (!countdownWrapper) {
+      if (!cardShell) {
         return;
       }
 
-      countdownWrapper.classList.remove('has-video');
-      countdownWrapper.classList.add('has-details');
-      countdownWrapper.innerHTML = '';
+      cardShell.innerHTML = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'countdown-wrapper has-details';
 
       const eyebrow = document.createElement('p');
       eyebrow.className = 'eyebrow';
@@ -84,32 +86,32 @@
       note.className = 'countdown-note save-date-note';
       note.textContent = 'Formal invite to follow';
 
-      countdownWrapper.appendChild(eyebrow);
-      countdownWrapper.appendChild(title);
-      countdownWrapper.appendChild(dateLine);
-      countdownWrapper.appendChild(note);
+      wrapper.appendChild(eyebrow);
+      wrapper.appendChild(title);
+      wrapper.appendChild(dateLine);
+      wrapper.appendChild(note);
 
-      if (cardShell) {
-        cardShell.classList.remove('is-video');
-        cardShell.classList.add('is-details');
-      }
+      cardShell.appendChild(wrapper);
+      cardShell.classList.remove('is-video');
+      cardShell.classList.add('is-details');
     };
 
     const showCelebrationVideo = () => {
-      if (!countdownWrapper) {
+      if (!cardShell) {
         return;
       }
 
-      countdownWrapper.classList.add('has-video');
-      countdownWrapper.classList.remove('has-details');
-      countdownWrapper.innerHTML = '';
+      cardShell.innerHTML = '';
 
-      const videoFrame = document.createElement('div');
-      videoFrame.className = 'countdown-video-frame';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'countdown-wrapper has-video';
 
       const videoHashtag = document.createElement('p');
       videoHashtag.className = 'video-hashtag';
       videoHashtag.textContent = '#BECOMINGCUMMINGS';
+
+      const videoFrame = document.createElement('div');
+      videoFrame.className = 'countdown-video-frame';
 
       const celebrationVideo = document.createElement('video');
       celebrationVideo.className = 'countdown-video';
@@ -127,16 +129,15 @@
       }, { once: true });
 
       videoFrame.appendChild(celebrationVideo);
-      countdownWrapper.appendChild(videoHashtag);
-      countdownWrapper.appendChild(videoFrame);
+      wrapper.appendChild(videoHashtag);
+      wrapper.appendChild(videoFrame);
 
-      if (cardShell) {
-        cardShell.classList.remove('is-details');
-        cardShell.classList.add('is-video');
-      }
+      cardShell.appendChild(wrapper);
+      cardShell.classList.remove('is-details');
+      cardShell.classList.add('is-video');
     };
 
-    if (countdownNumber) {
+    if (countdownNumber && initialCountdownWrapper) {
       countdownNumber.textContent = String(currentValue);
 
       const countdownInterval = window.setInterval(() => {
@@ -147,6 +148,9 @@
           countdownNumber.textContent = '0';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
+          if (countdownNote) {
+            countdownNote.textContent = "It's time to celebrate!";
+          }
           window.setTimeout(() => {
             showCelebrationVideo();
           }, 400);
@@ -159,6 +163,8 @@
           countdownNumber.classList.remove('is-transitioning');
         }, 200);
       }, 1000);
+    } else {
+      showCelebrationVideo();
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update the border flip countdown markup to match the structure used on the border page
- rework the countdown scripting to rebuild video/details views through the card shell container
- adjust countdown styling so the flip page numbers and notes follow the border page presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd85168228832ea0fcc93710473264