### PR TITLE
Enable audio playback for celebration video

### DIFF
--- a/border-flip.html
+++ b/border-flip.html
@@ -83,6 +83,7 @@
     const startOverlay = document.getElementById('startOverlay');
     let countdownInterval = null;
     let revealIndex = 0;
+    let hasUserInteracted = false;
 
     const totalCountdownSteps = countdownStart + 1;
     const totalBorderCells = borderCells.length;
@@ -210,8 +211,15 @@
       celebrationVideo.src = 'assets/video.mp4';
       celebrationVideo.autoplay = true;
       celebrationVideo.loop = false;
-      celebrationVideo.muted = true;
+      celebrationVideo.muted = !hasUserInteracted;
       celebrationVideo.setAttribute('playsinline', '');
+
+      if (!celebrationVideo.muted) {
+        celebrationVideo.removeAttribute('muted');
+        celebrationVideo.volume = 1;
+      } else {
+        celebrationVideo.setAttribute('muted', '');
+      }
 
       celebrationVideo.addEventListener('ended', () => {
         showSaveTheDateDetails();
@@ -223,6 +231,16 @@
       videoFrame.appendChild(celebrationVideo);
       countdownWrapper.appendChild(videoHashtag);
       countdownWrapper.appendChild(videoFrame);
+
+      const playPromise = celebrationVideo.play();
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => {
+          if (!celebrationVideo.muted) {
+            celebrationVideo.muted = true;
+            celebrationVideo.play().catch(() => {});
+          }
+        });
+      }
 
       if (cardShell) {
         cardShell.classList.remove('is-details');
@@ -267,20 +285,27 @@
       }, 1000);
     };
 
+    const markUserInteraction = () => {
+      hasUserInteracted = true;
+      audioCtx?.resume().catch(() => {});
+    };
+
     const handleOverlayKeydown = (event) => {
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
+        markUserInteraction();
         startCountdown();
       }
     };
 
     if (startOverlay) {
       startOverlay.addEventListener('click', () => {
-        audioCtx?.resume().catch(() => {});
+        markUserInteraction();
         startCountdown();
       });
       startOverlay.addEventListener('keydown', handleOverlayKeydown);
     } else if (countdownNumber) {
+      markUserInteraction();
       updateCountdownDisplay(currentValue);
       playBeat();
       applyRevealSchedule();


### PR DESCRIPTION
## Summary
- track whether the visitor has interacted with the countdown overlay
- unmute the celebration video after interaction and attempt playback with sound
- fall back to muted playback if browsers block audio autoplay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd8a2d100c832e8dbf1aa3068c157e