### PR TITLE
Improve border flip start prompt

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -401,7 +401,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(3, 40, 28, 0.9);
+  background: var(--emerald-dark);
   color: var(--cream);
   z-index: 5;
   font-family: var(--countdown-font);
@@ -425,13 +425,13 @@ body {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100%;
   padding: clamp(48px, 14vh, 160px) clamp(24px, 12vw, 80px);
-  gap: clamp(24px, 8vh, 48px);
-  pointer-events: none;
+  gap: clamp(28px, 7vh, 52px);
+  pointer-events: auto;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .countdown-overlay-line {
@@ -442,12 +442,46 @@ body {
   text-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
 }
 
-.countdown-overlay-line--top {
-  align-self: flex-start;
+.countdown-overlay-line--top,
+.countdown-overlay-line--bottom {
+  align-self: center;
 }
 
-.countdown-overlay-line--bottom {
-  align-self: flex-end;
+.countdown-overlay-button {
+  font-family: 'Spectral', serif;
+  font-size: clamp(0.8rem, 2.4vw, 1rem);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  padding: clamp(10px, 1.8vw, 14px) clamp(22px, 4vw, 32px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--cream);
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease,
+    border-color 0.25s ease, box-shadow 0.25s ease;
+  pointer-events: auto;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.countdown-overlay-button:hover,
+.countdown-overlay-button:focus-visible {
+  background: var(--cream);
+  color: var(--emerald-dark);
+  border-color: transparent;
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.32);
+}
+
+.countdown-overlay-button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.countdown-overlay-content.is-clearing {
+  opacity: 0;
+  transform: scale(0.97);
+  pointer-events: none;
 }
 
 .countdown-overlay::before {

--- a/border-flip.html
+++ b/border-flip.html
@@ -19,6 +19,7 @@
   >
     <div class="countdown-overlay-content">
       <span class="countdown-overlay-line countdown-overlay-line--top">get ready</span>
+      <button class="countdown-overlay-button" id="startCountdownButton" type="button">click here</button>
       <span class="countdown-overlay-line countdown-overlay-line--bottom">to party</span>
     </div>
   </div>
@@ -81,9 +82,14 @@
     const countdownStart = 10;
     let currentValue = countdownStart;
     const startOverlay = document.getElementById('startOverlay');
+    const startOverlayContent = startOverlay
+      ? startOverlay.querySelector('.countdown-overlay-content')
+      : null;
+    const startButton = document.getElementById('startCountdownButton');
     let countdownInterval = null;
     let revealIndex = 0;
     let hasUserInteracted = false;
+    let hasClearedStartPrompt = false;
 
     const totalCountdownSteps = countdownStart + 1;
     const totalBorderCells = borderCells.length;
@@ -248,11 +254,24 @@
       }
     };
 
+    const clearStartPrompt = () => {
+      if (hasClearedStartPrompt || !startOverlayContent) {
+        return;
+      }
+
+      hasClearedStartPrompt = true;
+      startOverlayContent.classList.add('is-clearing');
+      window.setTimeout(() => {
+        startOverlayContent.innerHTML = '';
+      }, 320);
+    };
+
     const startCountdown = () => {
       if (!countdownNumber || countdownInterval !== null) {
         return;
       }
 
+      clearStartPrompt();
       startOverlay?.classList.remove('start-prompt');
       startOverlay?.classList.add('is-counting');
       startOverlay?.setAttribute('aria-hidden', 'true');
@@ -330,6 +349,14 @@
           finishCountdown();
         }
       }, 1000);
+    }
+
+    if (startButton) {
+      startButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        markUserInteraction();
+        startCountdown();
+      });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add a centered "click here" button to the start overlay so the user knows how to begin
- ensure the overlay fully obscures the gallery and clear the prompt once the countdown begins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd8cf1a470832e816adba9393fa0b2