### PR TITLE
Adjust countdown container width

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -208,6 +208,8 @@ body {
   justify-content: center;
   text-align: center;
   gap: clamp(14px, 3.2vw, 26px);
+  width: 100%;
+  max-width: min(520px, 100%);
 }
 
 .countdown-wrapper.has-video {


### PR DESCRIPTION
## Summary
- expand the countdown wrapper so it spans the full width of the inner card frame

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd9560cd64832ea3bc8ed1c678ba93