### PR TITLE
Center countdown digits on border flip

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -256,7 +256,8 @@ body {
   color: var(--emerald-mid);
   text-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
   font-variant-numeric: tabular-nums;
-  margin-left: -0.12em;
+  margin-left: 0;
+  text-align: center;
   transition: transform 0.4s ease;
 }
 


### PR DESCRIPTION
## Summary
- remove the negative left margin on the countdown numeral and center-align its text
- ensure the countdown digits appear visually centered within the flip countdown card

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd9e2cc214832e8e92e12f52bb3652