### PR TITLE
Add slow spin reveal to border flip card

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -7,6 +7,7 @@
   --accent: #ffe3a2;
   --card-radius: clamp(24px, 4vw, 40px);
   --transition: 0.35s ease;
+  --card-spin-duration: 2.8s;
   --countdown-font: 'Cinzel Decorative', serif;
 }
 
@@ -151,6 +152,7 @@ body {
   align-items: center;
   justify-content: center;
   z-index: 2;
+  perspective: 1400px;
 }
 
 .card-shell {
@@ -166,10 +168,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  transform-style: preserve-3d;
 }
 
 .border-cell {
   z-index: 1;
+}
+
+.card-shell.is-revealing {
+  animation: slow-spin-reveal var(--card-spin-duration, 2.8s) ease-in-out forwards;
+  will-change: transform;
+  pointer-events: none;
 }
 
 .card-shell.is-video {
@@ -210,6 +219,8 @@ body {
   gap: clamp(14px, 3.2vw, 26px);
   width: 100%;
   max-width: min(520px, 100%);
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
 }
 
 .countdown-wrapper.has-video {
@@ -235,6 +246,7 @@ body {
   justify-content: flex-start;
   padding-top: clamp(24px, 4.2vw, 44px);
   max-width: min(520px, 100%);
+  animation: details-reveal 1s ease forwards;
 }
 
 .countdown-video-frame {
@@ -396,6 +408,46 @@ body {
   letter-spacing: 0.36em;
   font-size: clamp(0.62rem, 1.4vw, 0.78rem);
   color: rgba(12, 44, 29, 0.68);
+}
+
+@keyframes slow-spin-reveal {
+  0% {
+    transform: rotateY(0deg) scale(1);
+  }
+
+  45% {
+    transform: rotateY(92deg) scale(0.94);
+  }
+
+  55% {
+    transform: rotateY(92deg) scale(0.94);
+  }
+
+  100% {
+    transform: rotateY(0deg) scale(1);
+  }
+}
+
+@keyframes details-reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-shell.is-revealing {
+    animation: none;
+  }
+
+  .countdown-wrapper.has-details {
+    animation: none;
+  }
 }
 
 .countdown-overlay {

--- a/border-flip.html
+++ b/border-flip.html
@@ -103,6 +103,40 @@
       }
     }
 
+    const prefersReducedMotionQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+    let shouldReduceMotion = prefersReducedMotionQuery?.matches ?? false;
+
+    const updateMotionPreference = (event) => {
+      shouldReduceMotion = event.matches;
+    };
+
+    if (prefersReducedMotionQuery) {
+      if (typeof prefersReducedMotionQuery.addEventListener === 'function') {
+        prefersReducedMotionQuery.addEventListener('change', updateMotionPreference);
+      } else if (typeof prefersReducedMotionQuery.addListener === 'function') {
+        prefersReducedMotionQuery.addListener(updateMotionPreference);
+      }
+    }
+
+    const defaultSpinDurationMs = 2800;
+    const readSpinDuration = () => {
+      try {
+        const rootStyle = window.getComputedStyle(document.documentElement);
+        const rawValue = rootStyle?.getPropertyValue('--card-spin-duration');
+        const parsedSeconds = rawValue ? parseFloat(rawValue) : Number.NaN;
+        return Number.isFinite(parsedSeconds) ? parsedSeconds * 1000 : defaultSpinDurationMs;
+      } catch (error) {
+        return defaultSpinDurationMs;
+      }
+    };
+
+    let slowSpinDurationMs = readSpinDuration();
+    let slowSpinTimeoutId = null;
+    let hasRevealedDetails = false;
+
     const revealNextCells = (count = 1) => {
       for (let i = 0; i < count; i += 1) {
         if (revealIndex >= totalBorderCells) {
@@ -158,8 +192,14 @@
     }
 
     const showSaveTheDateDetails = () => {
-      if (!countdownWrapper) {
+      if (!countdownWrapper || hasRevealedDetails) {
         return;
+      }
+
+      hasRevealedDetails = true;
+      if (slowSpinTimeoutId !== null) {
+        window.clearTimeout(slowSpinTimeoutId);
+        slowSpinTimeoutId = null;
       }
 
       countdownWrapper.classList.remove('has-video');
@@ -193,7 +233,40 @@
       if (cardShell) {
         cardShell.classList.remove('is-video');
         cardShell.classList.add('is-details');
+        cardShell.classList.remove('is-revealing');
       }
+    };
+
+    const startSlowSpinReveal = () => {
+      if (hasRevealedDetails) {
+        return;
+      }
+
+      if (!cardShell || shouldReduceMotion) {
+        showSaveTheDateDetails();
+        return;
+      }
+
+      slowSpinDurationMs = readSpinDuration();
+      cardShell.classList.add('is-revealing');
+
+      if (slowSpinTimeoutId !== null) {
+        window.clearTimeout(slowSpinTimeoutId);
+      }
+
+      slowSpinTimeoutId = window.setTimeout(() => {
+        slowSpinTimeoutId = null;
+        showSaveTheDateDetails();
+      }, Math.max(0, Math.floor(slowSpinDurationMs * 0.5)));
+
+      const handleAnimationEnd = () => {
+        cardShell?.classList.remove('is-revealing');
+        if (!hasRevealedDetails) {
+          showSaveTheDateDetails();
+        }
+      };
+
+      cardShell.addEventListener('animationend', handleAnimationEnd, { once: true });
     };
 
     const showCelebrationVideo = () => {
@@ -227,12 +300,18 @@
         celebrationVideo.setAttribute('muted', '');
       }
 
-      celebrationVideo.addEventListener('ended', () => {
-        showSaveTheDateDetails();
-      });
-      celebrationVideo.addEventListener('error', () => {
-        showSaveTheDateDetails();
-      }, { once: true });
+      const handleVideoComplete = () => {
+        startSlowSpinReveal();
+      };
+
+      celebrationVideo.addEventListener('ended', handleVideoComplete, { once: true });
+      celebrationVideo.addEventListener(
+        'error',
+        () => {
+          handleVideoComplete();
+        },
+        { once: true }
+      );
 
       videoFrame.appendChild(celebrationVideo);
       countdownWrapper.appendChild(videoHashtag);


### PR DESCRIPTION
## Summary
- add a 3d-inspired spin animation and fade-in styling to the border flip card reveal
- trigger the slow spin transition after the celebration video ends while honoring reduced motion settings

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cda6580ec0832e8ad2ba74cb1ff51f