### PR TITLE
Improve mobile layout across gallery pages

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -600,12 +600,69 @@ body {
   }
 }
 
-@media (max-width: 520px) {
-  .page-border {
-    grid-template-columns: minmax(56px, 28vw) minmax(56px, 28vw) 1fr minmax(56px, 28vw);
-    grid-template-rows: minmax(56px, 26vh) minmax(56px, 26vh) 1fr minmax(56px, 26vh);
+@media (max-width: 640px) {
+  body {
+    display: block;
+    overflow-y: auto;
   }
 
+  .page-border {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: none;
+    grid-auto-rows: minmax(140px, 32vh);
+    grid-template-areas: none;
+    height: auto;
+    min-height: 100vh;
+    padding: clamp(16px, 8vw, 32px);
+    gap: clamp(12px, 6vw, 24px);
+    align-content: start;
+  }
+
+  .page-border > * {
+    grid-area: auto !important;
+  }
+
+  .content-card {
+    grid-column: 1 / -1;
+    padding: clamp(16px, 6vw, 30px);
+    margin: 0;
+  }
+
+  .card-shell {
+    width: 100%;
+    min-height: clamp(280px, 70vh, 480px);
+    padding: clamp(20px, 7vw, 34px);
+  }
+
+  .card-shell.is-video {
+    width: 100%;
+  }
+
+  .countdown-wrapper {
+    padding: clamp(22px, 7vw, 36px);
+    gap: clamp(16px, 6vw, 28px);
+  }
+
+  .countdown-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(10px, 4vw, 18px);
+  }
+
+  .countdown-overlay {
+    align-items: center;
+    justify-content: center;
+  }
+
+  .countdown-overlay-button {
+    width: min(260px, 80%);
+  }
+
+  .border-cell {
+    border-radius: clamp(16px, 8vw, 24px);
+  }
+}
+
+@media (max-width: 520px) {
   .card-shell::before {
     inset: clamp(10px, 3vw, 18px);
   }
@@ -620,8 +677,8 @@ body {
   }
 
   .countdown-grid {
-    grid-template-columns: repeat(4, minmax(64px, 1fr));
-    gap: clamp(8px, 3.6vw, 14px);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(10px, 4vw, 18px);
   }
 
   .save-date-title {

--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -487,12 +487,59 @@ h1 {
   }
 }
 
-@media (max-width: 520px) {
-  .page-border {
-    grid-template-columns: minmax(56px, 28vw) 1fr minmax(56px, 28vw);
-    grid-template-rows: minmax(56px, 26vh) 1fr minmax(56px, 26vh);
+@media (max-width: 640px) {
+  body {
+    display: block;
+    overflow-y: auto;
   }
 
+  .page-border {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: none;
+    grid-auto-rows: minmax(140px, 32vh);
+    grid-template-areas: none;
+    height: auto;
+    min-height: 100vh;
+    padding: clamp(16px, 8vw, 34px);
+    gap: clamp(12px, 6vw, 24px);
+    align-content: start;
+  }
+
+  .page-border > * {
+    grid-area: auto !important;
+  }
+
+  .content-card {
+    grid-column: 1 / -1;
+    margin: 0;
+    padding: clamp(18px, 7vw, 34px);
+  }
+
+  .card-shell {
+    max-width: none;
+    width: 100%;
+    min-height: clamp(280px, 68vh, 480px);
+  }
+
+  .countdown-wrapper {
+    padding: clamp(22px, 7vw, 36px);
+    gap: clamp(16px, 6vw, 28px);
+  }
+
+  .countdown-wrapper.has-video {
+    max-width: 100%;
+  }
+
+  .countdown-video-frame {
+    aspect-ratio: 4 / 3;
+  }
+
+  .border-cell {
+    border-radius: clamp(16px, 8vw, 24px);
+  }
+}
+
+@media (max-width: 520px) {
   .content-card::before {
     inset: clamp(10px, 3vw, 18px);
   }

--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -778,3 +778,156 @@ button.loading::after {
   text-align: center;
   line-height: 1.4;
 }
+
+@media (max-width: 900px) {
+  html,
+  body {
+    height: auto;
+    min-height: 100%;
+  }
+
+  body {
+    display: block;
+    overflow-y: auto;
+  }
+
+  body.no-scroll {
+    overflow: auto;
+  }
+
+  .gallery-stage {
+    height: auto;
+    min-height: 100vh;
+    padding: clamp(24px, 8vw, 60px) clamp(18px, 6vw, 48px);
+  }
+
+  .gallery-frame {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    width: min(640px, 100%);
+    margin: 0 auto;
+    height: auto;
+    padding: clamp(18px, 6vw, 40px);
+    gap: clamp(20px, 6vw, 36px);
+  }
+
+  .photo-grid {
+    display: none;
+  }
+
+  .intro-card-container {
+    grid-column: auto;
+    grid-row: auto;
+    height: auto;
+  }
+
+  .intro-card-shell {
+    min-height: clamp(320px, 70vh, 520px);
+    padding: clamp(26px, 8vw, 48px);
+  }
+
+  .flip-card {
+    max-width: none;
+  }
+
+  .wedding-names {
+    font-size: clamp(2rem, 10vw, 2.8rem);
+    letter-spacing: 0.08em;
+  }
+
+  .wedding-date {
+    font-size: clamp(1rem, 4.6vw, 1.28rem);
+    letter-spacing: 0.12em;
+  }
+
+  .countdown-overlay {
+    position: fixed;
+  }
+
+  .thank-you-container {
+    position: relative;
+    padding: clamp(40px, 12vw, 80px) clamp(18px, 6vw, 48px);
+  }
+
+  .thank-you-card {
+    width: min(520px, 100%);
+  }
+}
+
+@media (max-width: 560px) {
+  .intro-card-shell {
+    padding: clamp(20px, 10vw, 40px);
+  }
+
+  .flip-front,
+  .flip-back {
+    padding: clamp(18px, 7vw, 36px);
+  }
+
+  .wedding-names {
+    font-size: clamp(1.8rem, 11vw, 2.4rem);
+  }
+
+  .wedding-date {
+    font-size: clamp(0.92rem, 4.8vw, 1.16rem);
+    text-align: center;
+  }
+
+  .flip-back p {
+    font-size: clamp(0.95rem, 4.6vw, 1.1rem);
+  }
+
+  .cant-attend-btn,
+  .intro-card-container button {
+    width: 100%;
+  }
+
+  .countdown-stage {
+    padding: clamp(32px, 12vw, 64px) clamp(18px, 6vw, 44px);
+  }
+
+  .countdown-shell {
+    width: min(100%, 520px);
+    border-radius: clamp(24px, 8vw, 42px);
+    padding: clamp(22px, 8vw, 42px);
+  }
+
+  .countdown-layout {
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .countdown-overlay {
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 420px) {
+  .intro-card-shell {
+    border-radius: clamp(22px, 8vw, 32px);
+  }
+
+  .flip-card {
+    min-height: clamp(260px, 80vh, 420px);
+  }
+
+  .flip-front,
+  .flip-back {
+    gap: clamp(14px, 6vw, 24px);
+  }
+
+  .wedding-names {
+    letter-spacing: 0.06em;
+  }
+
+  .intro-card-container button {
+    font-size: clamp(0.94rem, 4.6vw, 1.04rem);
+  }
+
+  .thank-you-card {
+    padding: clamp(22px, 8vw, 32px);
+  }
+}


### PR DESCRIPTION
## Summary
- relax strict full-height layouts so the Save the Date, countdown, and thank-you screens flow vertically on small devices
- collapse bordered gallery and flip layouts into mobile-friendly two-column grids with adaptive card spacing and typography
- tighten small-screen styling for overlays, countdown grids, and buttons to keep interactions usable on phones

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cdb1826678832e9754c2a47fa5b23e