### PR TITLE
Align border flip photo layout with bordered page

### DIFF
--- a/assets/css/bordered-gallery-flip.css
+++ b/assets/css/bordered-gallery-flip.css
@@ -33,27 +33,21 @@ body {
   min-height: 100vh;
 }
 
+
 .page-border {
   display: grid;
-  grid-template-columns: minmax(110px, 18vw) minmax(110px, 18vw) 1fr minmax(110px, 18vw);
-  grid-template-rows: minmax(110px, 18vh) minmax(110px, 18vh) 1fr minmax(110px, 18vh);
-  grid-template-areas:
-    "top-left top-left-center top-right-center top-right"
-    "mid-left-upper content content mid-right-upper"
-    "mid-left-lower content content mid-right-lower"
-    "bottom-left bottom-left-center bottom-right-center bottom-right";
+  grid-template-columns: minmax(120px, 18vw) 1fr minmax(120px, 18vw);
+  grid-template-rows: minmax(120px, 20vh) 1fr minmax(120px, 20vh);
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   overflow: hidden;
-  gap: clamp(12px, 3vw, 26px);
-  padding: clamp(20px, 4vw, 48px);
+  padding: clamp(18px, 4vw, 48px);
 }
 
 .border-cell {
   position: relative;
   overflow: hidden;
   isolation: isolate;
-  border-radius: clamp(16px, 3vw, 28px);
   opacity: 0;
 }
 
@@ -97,53 +91,6 @@ body {
   filter: saturate(1) contrast(1.12);
 }
 
-.top-left {
-  grid-area: top-left;
-}
-
-.top-left-center {
-  grid-area: top-left-center;
-}
-
-.top-right-center {
-  grid-area: top-right-center;
-}
-
-.top-right {
-  grid-area: top-right;
-}
-
-.mid-left-upper {
-  grid-area: mid-left-upper;
-}
-
-.mid-left-lower {
-  grid-area: mid-left-lower;
-}
-
-.mid-right-upper {
-  grid-area: mid-right-upper;
-}
-
-.mid-right-lower {
-  grid-area: mid-right-lower;
-}
-
-.bottom-left {
-  grid-area: bottom-left;
-}
-
-.bottom-left-center {
-  grid-area: bottom-left-center;
-}
-
-.bottom-right-center {
-  grid-area: bottom-right-center;
-}
-
-.bottom-right {
-  grid-area: bottom-right;
-}
 
 .content-card {
   grid-area: content;

--- a/border-flip.html
+++ b/border-flip.html
@@ -25,12 +25,10 @@
   </div>
   <div class="page-border">
     <div class="border-cell top-left"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
-    <div class="border-cell top-left-center"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
-    <div class="border-cell top-right-center"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
-    <div class="border-cell top-right"><img src="assets/images/AUG4759_bw.jpg" alt="Walking through a meadow"></div>
+    <div class="border-cell top-center"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
+    <div class="border-cell top-right"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
 
-    <div class="border-cell mid-left-upper"><img src="assets/images/AUG4849_bw.jpg" alt="Strolling through the forest"></div>
-    <div class="border-cell mid-right-upper"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
+    <div class="border-cell middle-left"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
 
     <main class="content-card">
       <div class="card-shell">
@@ -42,13 +40,11 @@
       </div>
     </main>
 
-    <div class="border-cell mid-left-lower"><img src="assets/images/AUG5177_bw.jpg" alt="Sharing a quiet moment"></div>
-    <div class="border-cell mid-right-lower"><img src="assets/images/AUG5201_bw.jpg" alt="Couple embracing"></div>
+    <div class="border-cell middle-right"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
 
-    <div class="border-cell bottom-left"><img src="assets/images/AUG5253_bw.jpg" alt="Walking hand in hand"></div>
-    <div class="border-cell bottom-left-center"><img src="assets/images/AUG5279_bw.jpg" alt="Smiling together"></div>
-    <div class="border-cell bottom-right-center"><img src="assets/images/AUG5290_bw.jpg" alt="Dancing under string lights"></div>
-    <div class="border-cell bottom-right"><img src="assets/images/AUG5306_bw.jpg" alt="Laughing near the lake"></div>
+    <div class="border-cell bottom-left"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>
+    <div class="border-cell bottom-center"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
+    <div class="border-cell bottom-right"><img src="assets/images/AUG5139_bw.jpg" alt="Walking by the lake"></div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- reuse the bordered layout on the flip experience so photos frame the page the same way
- trim the extra border cells from the flip markup and match the shared image set
- simplify the flip CSS grid to mirror the bordered gallery presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbab6440c832ea1efb7c6078f506d