### PR TITLE
Center countdown frame and unify sizing

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -106,6 +106,9 @@ body {
   justify-content: center;
   margin: 0;
   border: 1px solid rgba(12, 44, 29, 0.16);
+  align-self: center;
+  justify-self: center;
+  width: min(100%, 720px);
 }
 
 .content-card::before {
@@ -124,9 +127,8 @@ body {
 
 .card-shell {
   position: relative;
-  width: 100%;
-  max-width: 520px;
-  min-height: clamp(320px, 52vw, 520px);
+  width: min(560px, 100%);
+  min-height: clamp(320px, 58vw, 520px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -148,12 +150,14 @@ body {
   justify-content: center;
   text-align: center;
   gap: clamp(18px, 4vw, 30px);
+  width: 100%;
+  min-height: inherit;
 }
 
 .countdown-wrapper.has-video {
   gap: clamp(10px, 2.6vw, 18px);
   padding: clamp(16px, 3.6vw, 30px);
-  max-width: min(640px, 100%);
+  justify-content: center;
 }
 
 .countdown-wrapper.has-details {
@@ -163,7 +167,6 @@ body {
   padding: clamp(30px, 4.8vw, 48px);
   gap: clamp(12px, 3.8vw, 24px);
   align-items: center;
-  max-width: min(520px, 100%);
 }
 
 .countdown-number {
@@ -189,13 +192,15 @@ body {
 
 .countdown-video-frame {
   width: 100%;
-  max-width: 620px;
   border-radius: clamp(16px, 3vw, 28px);
   overflow: hidden;
   aspect-ratio: 16 / 9;
   background: #000;
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
   border: 1.5px solid var(--card-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .countdown-video {


### PR DESCRIPTION
## Summary
- center the bordered countdown frame within the page grid and constrain its overall width
- apply a consistent minimum frame size for the countdown, video, and save-the-date states and ensure the video frame fills the available space

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdc7703a80832ebfe8aed1166beefa