### PR TITLE
Fix intro card layout and photo grid coverage

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -64,8 +64,12 @@ html, body {
   grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-template-rows: repeat(5, minmax(0, 1fr));
   gap: inherit;
-  justify-content: center;
-  align-content: center;
+  justify-content: stretch;
+  align-content: stretch;
+  justify-items: stretch;
+  align-items: stretch;
+  grid-auto-rows: minmax(0, 1fr);
+  grid-auto-columns: minmax(0, 1fr);
   pointer-events: none;
 }
 
@@ -87,6 +91,7 @@ html, body {
   overflow: hidden;
   box-shadow: 0 26px 46px rgba(0,0,0,0.35);
   background: rgba(255,255,255,0.05);
+  aspect-ratio: 3 / 4;
 }
 
 .photo-grid .countdown-image.active {
@@ -113,17 +118,20 @@ html, body {
 .intro-card-container {
   grid-column: 2 / span 3;
   grid-row: 2 / span 3;
+  position: absolute;
+  top: 50%;
+  left: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  max-height: 100%;
+  width: min(68vw, 540px);
+  max-width: 540px;
+  transform: translate(-50%, -50%);
 }
 
 .intro-card-shell {
   width: 100%;
-  height: 100%;
-  max-height: 100%;
+  height: auto;
   background: var(--white);
   color: var(--bg-emerald-dark);
   border-radius: clamp(28px, 4vw, 46px);
@@ -545,11 +553,10 @@ html, body {
 }
 
 .intro-card-container {
-  position: relative;
   z-index: 1;
   pointer-events: none;
   opacity: 0;
-  transform: perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-4deg) scale(0.86);
+  transform: translate(-50%, -50%) perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-4deg) scale(0.86);
   transform-origin: center;
   transform-style: preserve-3d;
   will-change: transform, opacity;
@@ -571,7 +578,7 @@ html, body {
 
 @media (prefers-reduced-motion: reduce) {
   .intro-card-container {
-    transform: none;
+    transform: translate(-50%, -50%);
   }
 
   .intro-card-container.visible {
@@ -731,15 +738,15 @@ button.loading::after {
 @keyframes card-reveal-spin {
   0% {
     opacity: 0;
-    transform: perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-6deg) scale(0.78);
+    transform: translate(-50%, -50%) perspective(1400px) rotateX(18deg) rotateY(-20deg) rotateZ(-6deg) scale(0.78);
   }
   55% {
     opacity: 1;
-    transform: perspective(1400px) rotateX(-6deg) rotateY(8deg) rotateZ(3deg) scale(1.04);
+    transform: translate(-50%, -50%) perspective(1400px) rotateX(-6deg) rotateY(8deg) rotateZ(3deg) scale(1.04);
   }
   100% {
     opacity: 1;
-    transform: perspective(1400px) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1);
+    transform: translate(-50%, -50%) perspective(1400px) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1);
   }
 }
 
@@ -820,7 +827,17 @@ button.loading::after {
   .intro-card-container {
     grid-column: auto;
     grid-row: auto;
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    max-width: none;
     height: auto;
+    transform: none;
+  }
+
+  .intro-card-container.visible {
+    animation: none;
   }
 
   .intro-card-shell {


### PR DESCRIPTION
## Summary
- center the intro card independently of the surrounding photo grid so it no longer inherits sizing from adjacent images
- stretch the surrounding gallery grid so photo frames appear on all sides and maintain consistent proportions
- ensure responsive and reduced-motion fallbacks keep the centered card usable on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdcc6e2ab0832eb2a1a1fbe443d6b5