### PR TITLE
Expand border gallery and sync reveal with countdown

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -32,8 +32,14 @@ body {
 
 .page-border {
   display: grid;
-  grid-template-columns: minmax(120px, 18vw) 1fr minmax(120px, 18vw);
-  grid-template-rows: minmax(120px, 20vh) 1fr minmax(120px, 20vh);
+  grid-template-columns: minmax(120px, 18vw) minmax(220px, 1fr) minmax(220px, 1fr) minmax(120px, 18vw);
+  grid-template-rows: minmax(120px, 20vh) minmax(160px, 24vh) minmax(160px, 24vh) minmax(120px, 20vh);
+  grid-template-areas:
+    'top-left top-left-center top-right-center top-right'
+    'middle-left main main middle-right'
+    'middle-left-lower main main middle-right-lower'
+    'bottom-left bottom-left-center bottom-right-center bottom-right';
+  gap: clamp(12px, 3vw, 30px);
   width: 100%;
   height: 100vh;
   overflow: hidden;
@@ -44,24 +50,14 @@ body {
   position: relative;
   overflow: hidden;
   isolation: isolate;
-}
-
-.border-cell.is-ready {
   opacity: 0;
-  animation: border-cell-in 1.6s ease-out forwards;
-  animation-delay: var(--border-cell-delay, 0s);
+  transform: translateY(24px) scale(0.94);
+  transition: opacity 0.9s ease, transform 0.9s ease;
 }
 
-@keyframes border-cell-in {
-  0% {
-    opacity: 0;
-    transform: translateY(18px) scale(0.97);
-  }
-
-  100% {
-    opacity: 1;
-    transform: none;
-  }
+.border-cell.is-visible {
+  opacity: 1;
+  transform: none;
 }
 
 .border-cell::after {
@@ -88,10 +84,59 @@ body {
   filter: saturate(1) contrast(1.1);
 }
 
+.border-cell.top-left {
+  grid-area: top-left;
+}
+
+.border-cell.top-left-center {
+  grid-area: top-left-center;
+}
+
+.border-cell.top-right-center {
+  grid-area: top-right-center;
+}
+
+.border-cell.top-right {
+  grid-area: top-right;
+}
+
+.border-cell.middle-left {
+  grid-area: middle-left;
+}
+
+.border-cell.middle-left-lower {
+  grid-area: middle-left-lower;
+}
+
+.border-cell.middle-right {
+  grid-area: middle-right;
+}
+
+.border-cell.middle-right-lower {
+  grid-area: middle-right-lower;
+}
+
+.border-cell.bottom-left {
+  grid-area: bottom-left;
+}
+
+.border-cell.bottom-left-center {
+  grid-area: bottom-left-center;
+}
+
+.border-cell.bottom-right-center {
+  grid-area: bottom-right-center;
+}
+
+.border-cell.bottom-right {
+  grid-area: bottom-right;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .border-cell.is-ready {
-    animation: none;
+  .border-cell {
+    transition: none;
     opacity: 1;
+    transform: none;
   }
 }
 
@@ -109,6 +154,7 @@ body {
   align-self: center;
   justify-self: center;
   width: min(100%, 720px);
+  grid-area: main;
 }
 
 .content-card::before {

--- a/border.html
+++ b/border.html
@@ -11,45 +11,64 @@
 </head>
 <body>
   <div class="page-border">
-    <div class="border-cell top-left"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
-    <div class="border-cell top-center"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
-    <div class="border-cell top-right"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
+    <div class="border-cell top-left" data-reveal-index="1"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
+    <div class="border-cell top-left-center" data-reveal-index="2"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
+    <div class="border-cell top-right-center" data-reveal-index="3"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
+    <div class="border-cell top-right" data-reveal-index="4"><img src="assets/images/AUG4759_bw.jpg" alt="Sharing a quiet moment together"></div>
 
-    <div class="border-cell middle-left"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
+    <div class="border-cell middle-left" data-reveal-index="5"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
+    <div class="border-cell middle-left-lower" data-reveal-index="6"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
     <main class="content-card">
       <div class="card-shell" id="cardShell">
         <div class="countdown-wrapper" aria-live="polite">
           <p class="eyebrow">Celebration Countdown</p>
-          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown at 10">10</div>
+          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown starting">10</div>
           <p class="countdown-note">Counting down the final moments until the big day.</p>
         </div>
       </div>
     </main>
-    <div class="border-cell middle-right"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
+    <div class="border-cell middle-right" data-reveal-index="7"><img src="assets/images/AUG5177_bw.jpg" alt="Laughing in the field"></div>
+    <div class="border-cell middle-right-lower" data-reveal-index="8"><img src="assets/images/AUG5181_bw.jpg" alt="A spin in the meadow"></div>
 
-    <div class="border-cell bottom-left"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>
-    <div class="border-cell bottom-center"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
-    <div class="border-cell bottom-right"><img src="assets/images/AUG5139_bw.jpg" alt="Walking by the lake"></div>
+    <div class="border-cell bottom-left" data-reveal-index="9"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>
+    <div class="border-cell bottom-left-center" data-reveal-index="10"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
+    <div class="border-cell bottom-right-center" data-reveal-index="11"><img src="assets/images/AUG5139_bw.jpg" alt="Walking by the lake"></div>
+    <div class="border-cell bottom-right" data-reveal-index="12"><img src="assets/images/AUG5201_bw.jpg" alt="Strolling along the shoreline"></div>
   </div>
   <script>
-    const borderCells = Array.from(document.querySelectorAll('.border-cell'));
-
-    borderCells.forEach((cell, index) => {
-      cell.style.setProperty('--border-cell-delay', `${index * 0.35}s`);
+    const borderCells = Array.from(document.querySelectorAll('.border-cell')).sort((first, second) => {
+      const firstIndex = Number(first.dataset.revealIndex) || 0;
+      const secondIndex = Number(second.dataset.revealIndex) || 0;
+      return firstIndex - secondIndex;
     });
 
-    requestAnimationFrame(() => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
       borderCells.forEach((cell) => {
-        cell.classList.add('is-ready');
+        cell.classList.add('is-visible');
       });
-    });
+    }
 
     const cardShell = document.getElementById('cardShell');
     const initialCountdownWrapper = cardShell?.querySelector('.countdown-wrapper');
     const countdownNumber = document.getElementById('countdownNumber');
     const countdownNote = initialCountdownWrapper?.querySelector('.countdown-note');
-    const countdownStart = 10;
+    const countdownStart = borderCells.length > 0 ? borderCells.length : 10;
     let currentValue = countdownStart;
+    let revealedCells = 0;
+
+    const revealNextBorderCell = () => {
+      if (prefersReducedMotion) {
+        return;
+      }
+
+      const nextCell = borderCells[revealedCells];
+      if (nextCell) {
+        nextCell.classList.add('is-visible');
+        revealedCells += 1;
+      }
+    };
 
     const showSaveTheDateDetails = () => {
       if (!cardShell) return;
@@ -124,6 +143,8 @@
 
     if (countdownNumber && initialCountdownWrapper) {
       countdownNumber.textContent = String(currentValue);
+      countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
+      revealNextBorderCell();
       const countdownInterval = window.setInterval(() => {
         currentValue -= 1;
         countdownNumber.classList.add('is-transitioning');
@@ -132,6 +153,7 @@
           countdownNumber.textContent = '0';
           countdownNumber.setAttribute('aria-label', 'Countdown finished');
           window.clearInterval(countdownInterval);
+          revealNextBorderCell();
           if (countdownNote) {
             countdownNote.textContent = "It's time to celebrate!";
           }
@@ -141,12 +163,13 @@
         } else {
           countdownNumber.textContent = String(currentValue);
           countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
+          revealNextBorderCell();
         }
 
         window.setTimeout(() => {
           countdownNumber.classList.remove('is-transitioning');
-        }, 200);
-      }, 1000);
+        }, 360);
+      }, 1100);
     } else {
       showCelebrationVideo();
     }


### PR DESCRIPTION
## Summary
- expand the border layout to showcase twelve unique photos around the invitation card
- slow the animation by revealing each border image in step with the countdown progression
- improve the countdown script for reduced-motion users and clearer accessibility labels

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cdd5742a08832e96e6122d5d2a17b4