### PR TITLE
Remove spacing between border gallery images

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -39,7 +39,7 @@ body {
     'middle-left main main middle-right'
     'middle-left-lower main main middle-right-lower'
     'bottom-left bottom-left-center bottom-right-center bottom-right';
-  gap: clamp(12px, 3vw, 30px);
+  gap: 0;
   width: 100%;
   height: 100vh;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- update the bordered gallery grid layout so adjacent photos touch without spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cddb89cd7c832eac712acb74aae247