### PR TITLE
Adjust border gallery layout with varied image sizes

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -32,14 +32,14 @@ body {
 
 .page-border {
   display: grid;
-  grid-template-columns: minmax(120px, 18vw) minmax(220px, 1fr) minmax(220px, 1fr) minmax(120px, 18vw);
-  grid-template-rows: minmax(120px, 20vh) minmax(160px, 24vh) minmax(160px, 24vh) minmax(120px, 20vh);
+  grid-template-columns: minmax(120px, 18vw) minmax(200px, 1fr) minmax(200px, 1fr) minmax(120px, 18vw);
+  grid-template-rows: minmax(120px, 18vh) minmax(160px, 24vh) minmax(160px, 24vh) minmax(120px, 18vh);
   grid-template-areas:
-    'top-left top-left-center top-right-center top-right'
-    'middle-left main main middle-right'
-    'middle-left-lower main main middle-right-lower'
-    'bottom-left bottom-left-center bottom-right-center bottom-right';
-  gap: 0;
+    'top-left-wide top-left-wide top-center top-right'
+    'middle-left-tall main main right-tall'
+    'middle-left-tall main main right-tall'
+    'bottom-left bottom-wide bottom-wide bottom-right';
+  gap: clamp(8px, 2vw, 18px);
   width: 100%;
   height: 100vh;
   overflow: hidden;
@@ -84,48 +84,32 @@ body {
   filter: saturate(1) contrast(1.1);
 }
 
-.border-cell.top-left {
-  grid-area: top-left;
+.border-cell.top-left-wide {
+  grid-area: top-left-wide;
 }
 
-.border-cell.top-left-center {
-  grid-area: top-left-center;
-}
-
-.border-cell.top-right-center {
-  grid-area: top-right-center;
+.border-cell.top-center {
+  grid-area: top-center;
 }
 
 .border-cell.top-right {
   grid-area: top-right;
 }
 
-.border-cell.middle-left {
-  grid-area: middle-left;
+.border-cell.middle-left-tall {
+  grid-area: middle-left-tall;
 }
 
-.border-cell.middle-left-lower {
-  grid-area: middle-left-lower;
-}
-
-.border-cell.middle-right {
-  grid-area: middle-right;
-}
-
-.border-cell.middle-right-lower {
-  grid-area: middle-right-lower;
+.border-cell.right-tall {
+  grid-area: right-tall;
 }
 
 .border-cell.bottom-left {
   grid-area: bottom-left;
 }
 
-.border-cell.bottom-left-center {
-  grid-area: bottom-left-center;
-}
-
-.border-cell.bottom-right-center {
-  grid-area: bottom-right-center;
+.border-cell.bottom-wide {
+  grid-area: bottom-wide;
 }
 
 .border-cell.bottom-right {

--- a/border.html
+++ b/border.html
@@ -11,13 +11,11 @@
 </head>
 <body>
   <div class="page-border">
-    <div class="border-cell top-left" data-reveal-index="1"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
-    <div class="border-cell top-left-center" data-reveal-index="2"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
-    <div class="border-cell top-right-center" data-reveal-index="3"><img src="assets/images/AUG4738_bw.jpg" alt="Looking at each other"></div>
-    <div class="border-cell top-right" data-reveal-index="4"><img src="assets/images/AUG4759_bw.jpg" alt="Sharing a quiet moment together"></div>
+    <div class="border-cell top-left-wide" data-reveal-index="1"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
+    <div class="border-cell top-center" data-reveal-index="2"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
+    <div class="border-cell top-right" data-reveal-index="3"><img src="assets/images/AUG4759_bw.jpg" alt="Sharing a quiet moment together"></div>
 
-    <div class="border-cell middle-left" data-reveal-index="5"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
-    <div class="border-cell middle-left-lower" data-reveal-index="6"><img src="assets/images/AUG4869_bw.jpg" alt="Dancing together"></div>
+    <div class="border-cell middle-left-tall" data-reveal-index="4"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
     <main class="content-card">
       <div class="card-shell" id="cardShell">
         <div class="countdown-wrapper" aria-live="polite">
@@ -27,13 +25,11 @@
         </div>
       </div>
     </main>
-    <div class="border-cell middle-right" data-reveal-index="7"><img src="assets/images/AUG5177_bw.jpg" alt="Laughing in the field"></div>
-    <div class="border-cell middle-right-lower" data-reveal-index="8"><img src="assets/images/AUG5181_bw.jpg" alt="A spin in the meadow"></div>
+    <div class="border-cell right-tall" data-reveal-index="5"><img src="assets/images/AUG5177_bw.jpg" alt="Laughing in the field"></div>
 
-    <div class="border-cell bottom-left" data-reveal-index="9"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>
-    <div class="border-cell bottom-left-center" data-reveal-index="10"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
-    <div class="border-cell bottom-right-center" data-reveal-index="11"><img src="assets/images/AUG5139_bw.jpg" alt="Walking by the lake"></div>
-    <div class="border-cell bottom-right" data-reveal-index="12"><img src="assets/images/AUG5201_bw.jpg" alt="Strolling along the shoreline"></div>
+    <div class="border-cell bottom-left" data-reveal-index="6"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>
+    <div class="border-cell bottom-wide" data-reveal-index="7"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
+    <div class="border-cell bottom-right" data-reveal-index="8"><img src="assets/images/AUG5201_bw.jpg" alt="Strolling along the shoreline"></div>
   </div>
   <script>
     const borderCells = Array.from(document.querySelectorAll('.border-cell')).sort((first, second) => {


### PR DESCRIPTION
## Summary
- reduce the border gallery around the countdown card to eight photos and update the reveal order
- redesign the grid so certain frames span multiple cells for a varied layout and add spacing between tiles

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cddd5a0cb8832e8b3543b38d2bb305