### PR TITLE
Add interactive countdown overlay and audio to border page

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -200,6 +200,105 @@ body {
   min-height: inherit;
 }
 
+.countdown-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--emerald-dark);
+  color: var(--cream);
+  z-index: 5;
+  font-family: var(--countdown-font);
+  font-size: clamp(2.6rem, 9vw, 6rem);
+  letter-spacing: 0.2em;
+  transition: opacity 0.6s ease;
+  overflow: hidden;
+}
+
+.countdown-overlay.start-prompt {
+  cursor: pointer;
+}
+
+.countdown-overlay:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 6px;
+}
+
+.countdown-overlay-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: clamp(48px, 14vh, 160px) clamp(24px, 12vw, 80px);
+  gap: clamp(28px, 7vh, 52px);
+  pointer-events: auto;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.countdown-overlay-line {
+  display: block;
+  width: 100%;
+  text-align: center;
+  text-transform: uppercase;
+  text-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+}
+
+.countdown-overlay-line--top,
+.countdown-overlay-line--bottom {
+  align-self: center;
+}
+
+.countdown-overlay-button {
+  font-family: 'Spectral', serif;
+  font-size: clamp(0.8rem, 2.4vw, 1rem);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  padding: clamp(10px, 1.8vw, 14px) clamp(22px, 4vw, 32px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--cream);
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease,
+    border-color 0.25s ease, box-shadow 0.25s ease;
+  pointer-events: auto;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.countdown-overlay-button:hover,
+.countdown-overlay-button:focus-visible {
+  background: var(--cream);
+  color: var(--emerald-dark);
+  border-color: transparent;
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.32);
+}
+
+.countdown-overlay-button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.countdown-overlay-content.is-clearing {
+  opacity: 0;
+  transform: scale(0.97);
+  pointer-events: none;
+}
+
+.countdown-overlay.is-counting {
+  background: transparent;
+  pointer-events: none;
+}
+
+.countdown-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .countdown-wrapper.has-video {
   gap: clamp(10px, 2.6vw, 18px);
   padding: clamp(16px, 3.6vw, 30px);
@@ -593,5 +692,9 @@ h1 {
 @media (max-width: 520px) {
   .content-card::before {
     inset: clamp(10px, 3vw, 18px);
+  }
+
+  .countdown-overlay-line {
+    font-size: clamp(2.2rem, 12vw, 4.4rem);
   }
 }

--- a/border.html
+++ b/border.html
@@ -10,6 +10,19 @@
   <link rel="stylesheet" href="assets/css/bordered-gallery.css">
 </head>
 <body>
+  <div
+    class="countdown-overlay start-prompt"
+    id="startOverlay"
+    role="button"
+    tabindex="0"
+    aria-label="Start the countdown"
+  >
+    <div class="countdown-overlay-content">
+      <span class="countdown-overlay-line countdown-overlay-line--top">get ready</span>
+      <button class="countdown-overlay-button" id="startCountdownButton" type="button">click here</button>
+      <span class="countdown-overlay-line countdown-overlay-line--bottom">to party</span>
+    </div>
+  </div>
   <div class="page-border">
     <div class="border-cell top-left" data-reveal-index="1"><img src="assets/images/AUG4710_bw.jpg" alt="Couple laughing together"></div>
     <div class="border-cell top-left-center" data-reveal-index="2"><img src="assets/images/AUG4726_bw.jpg" alt="Holding hands"></div>
@@ -36,13 +49,40 @@
     <div class="border-cell bottom-right" data-reveal-index="12"><img src="assets/images/AUG5201_bw.jpg" alt="Strolling along the shoreline"></div>
   </div>
   <script>
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = AudioContext ? new AudioContext() : null;
+
+    const playBeat = () => {
+      if (!audioCtx) return;
+      if (audioCtx.state === 'suspended') {
+        audioCtx.resume().catch(() => {});
+      }
+
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(82, audioCtx.currentTime);
+      osc.connect(gain);
+      gain.connect(audioCtx.destination);
+
+      const now = audioCtx.currentTime;
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(1.3, now + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.34);
+      osc.start(now);
+      osc.stop(now + 0.34);
+    };
+
     const borderCells = Array.from(document.querySelectorAll('.border-cell')).sort((first, second) => {
       const firstIndex = Number(first.dataset.revealIndex) || 0;
       const secondIndex = Number(second.dataset.revealIndex) || 0;
       return firstIndex - secondIndex;
     });
 
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const prefersReducedMotionQuery = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+    const prefersReducedMotion = prefersReducedMotionQuery?.matches ?? false;
 
     if (prefersReducedMotion) {
       borderCells.forEach((cell) => {
@@ -57,6 +97,12 @@
     const countdownStart = borderCells.length > 0 ? borderCells.length : 10;
     let currentValue = countdownStart;
     let revealedCells = 0;
+    let countdownIntervalId = null;
+    let hasStarted = false;
+
+    const startOverlay = document.getElementById('startOverlay');
+    const startOverlayContent = startOverlay?.querySelector('.countdown-overlay-content') ?? null;
+    const startButton = document.getElementById('startCountdownButton');
 
     const revealNextBorderCell = () => {
       if (prefersReducedMotion) {
@@ -122,7 +168,8 @@
       celebrationVideo.className = 'countdown-video';
       celebrationVideo.src = 'assets/video.mp4';
       celebrationVideo.autoplay = true;
-      celebrationVideo.muted = true;
+      celebrationVideo.muted = false;
+      celebrationVideo.controls = true;
       celebrationVideo.setAttribute('playsinline', '');
 
       celebrationVideo.addEventListener('ended', () => {
@@ -139,39 +186,107 @@
       wrapper.appendChild(videoFrame);
 
       cardShell.appendChild(wrapper);
+
+      const attemptVideoPlayback = () => {
+        const playPromise = celebrationVideo.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(() => {});
+        }
+      };
+
+      if (celebrationVideo.readyState >= 2) {
+        attemptVideoPlayback();
+      } else {
+        celebrationVideo.addEventListener('canplay', attemptVideoPlayback, { once: true });
+      }
+    };
+    const handleCountdownTick = () => {
+      if (!countdownNumber) {
+        return;
+      }
+
+      currentValue -= 1;
+      countdownNumber.classList.add('is-transitioning');
+      playBeat();
+
+      if (currentValue <= 0) {
+        countdownNumber.textContent = '0';
+        countdownNumber.setAttribute('aria-label', 'Countdown finished');
+        window.clearInterval(countdownIntervalId);
+        revealNextBorderCell();
+        if (countdownNote) {
+          countdownNote.textContent = "It's time to celebrate!";
+        }
+        window.setTimeout(() => {
+          showCelebrationVideo();
+        }, 400);
+      } else {
+        countdownNumber.textContent = String(currentValue);
+        countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
+        revealNextBorderCell();
+      }
+
+      window.setTimeout(() => {
+        countdownNumber.classList.remove('is-transitioning');
+      }, 360);
     };
 
-    if (countdownNumber && initialCountdownWrapper) {
+    const startCountdownFlow = () => {
+      if (!countdownNumber || !initialCountdownWrapper) {
+        showCelebrationVideo();
+        return;
+      }
+
       countdownNumber.textContent = String(currentValue);
       countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
       revealNextBorderCell();
-      const countdownInterval = window.setInterval(() => {
-        currentValue -= 1;
-        countdownNumber.classList.add('is-transitioning');
+      playBeat();
+      countdownIntervalId = window.setInterval(handleCountdownTick, 1100);
+    };
 
-        if (currentValue <= 0) {
-          countdownNumber.textContent = '0';
-          countdownNumber.setAttribute('aria-label', 'Countdown finished');
-          window.clearInterval(countdownInterval);
-          revealNextBorderCell();
-          if (countdownNote) {
-            countdownNote.textContent = "It's time to celebrate!";
-          }
-          window.setTimeout(() => {
-            showCelebrationVideo();
-          }, 400);
-        } else {
-          countdownNumber.textContent = String(currentValue);
-          countdownNumber.setAttribute('aria-label', `Countdown at ${currentValue}`);
-          revealNextBorderCell();
-        }
+    const startExperience = () => {
+      if (hasStarted) {
+        return;
+      }
 
+      hasStarted = true;
+
+      if (startOverlayContent) {
+        startOverlayContent.classList.add('is-clearing');
+      }
+
+      if (startOverlay) {
+        startOverlay.classList.add('is-counting');
         window.setTimeout(() => {
-          countdownNumber.classList.remove('is-transitioning');
-        }, 360);
-      }, 1100);
-    } else {
-      showCelebrationVideo();
+          startOverlay.classList.add('hidden');
+        }, 420);
+      }
+
+      if (audioCtx && audioCtx.state === 'suspended') {
+        audioCtx.resume().catch(() => {});
+      }
+
+      startCountdownFlow();
+    };
+
+    const handleOverlayKeyDown = (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        startExperience();
+      }
+    };
+
+    if (startButton) {
+      startButton.addEventListener('click', startExperience);
+    }
+
+    if (startOverlay) {
+      startOverlay.addEventListener('click', startExperience);
+      startOverlay.addEventListener('keydown', handleOverlayKeyDown);
+    }
+
+    if (!startOverlay || !startButton) {
+      startExperience();
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add the start prompt overlay and audio-enabled countdown flow to the border page
- restore video audio playback with controls after the countdown completes
- style the new overlay elements in the bordered gallery stylesheet

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cddda0e2e8832e84525591592a0aa2