### PR TITLE
Adjust border photo spacing

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -39,11 +39,11 @@ body {
     'middle-left-tall main main right-tall'
     'middle-left-tall main main right-tall'
     'bottom-left bottom-wide bottom-wide bottom-right';
-  gap: clamp(8px, 2vw, 18px);
+  gap: 0;
   width: 100%;
   height: 100vh;
   overflow: hidden;
-  padding: clamp(18px, 4vw, 48px);
+  padding: 0;
 }
 
 .border-cell {


### PR DESCRIPTION
## Summary
- remove grid gap and outer padding on the bordered gallery layout so the border photos directly touch each other and the page edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cde0a4d930832e89c2deffe944b41c