### PR TITLE
Make gallery grid flush with viewport

### DIFF
--- a/assets/css/save-the-date.css
+++ b/assets/css/save-the-date.css
@@ -33,9 +33,9 @@ html, body {
 .gallery-stage {
   height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(24px, 6vw, 72px);
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 0;
   background: radial-gradient(circle at top left, rgba(0, 87, 60, 0.32), transparent 55%),
               radial-gradient(circle at bottom right, rgba(0, 87, 60, 0.28), transparent 50%),
               var(--bg-emerald-dark);
@@ -43,17 +43,17 @@ html, body {
 
 .gallery-frame {
   position: relative;
-  width: min(1100px, 100%);
+  width: 100%;
   height: 100%;
-  max-height: 100%;
+  max-height: none;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   grid-template-rows: repeat(5, minmax(0, 1fr));
   gap: clamp(14px, 3vw, 40px);
-  padding: clamp(20px, 4vw, 60px);
+  padding: 0;
   box-sizing: border-box;
-  justify-content: center;
-  align-content: center;
+  justify-content: stretch;
+  align-content: stretch;
 }
 
 .photo-grid {


### PR DESCRIPTION
## Summary
- remove the outer padding on the gallery stage and frame so the photo grid can touch every edge of the screen
- allow the gallery frame to stretch to the full viewport width and height so the photos reach the bottom of the page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cde2930128832ebc1b8930c27bdba5