### PR TITLE
Remove content card wrapper from border page

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -157,6 +157,9 @@ body {
 
 .card-shell {
   position: relative;
+  grid-area: main;
+  align-self: center;
+  justify-self: center;
   width: min(560px, 100%);
   min-height: clamp(320px, 58vw, 520px);
   display: flex;

--- a/border.html
+++ b/border.html
@@ -29,15 +29,13 @@
     <div class="border-cell top-right" data-reveal-index="3"><img src="assets/images/AUG4759_bw.jpg" alt="Sharing a quiet moment together"></div>
 
     <div class="border-cell middle-left-tall" data-reveal-index="4"><img src="assets/images/AUG4849_bw.jpg" alt="Walking through the forest"></div>
-    <main class="content-card">
-      <div class="card-shell" id="cardShell">
-        <div class="countdown-wrapper" aria-live="polite">
-          <p class="eyebrow">Celebration Countdown</p>
-          <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown starting">10</div>
-          <p class="countdown-note">Counting down the final moments until the big day.</p>
-        </div>
+    <div class="card-shell" id="cardShell">
+      <div class="countdown-wrapper" aria-live="polite">
+        <p class="eyebrow">Celebration Countdown</p>
+        <div class="countdown-number" id="countdownNumber" role="status" aria-label="Countdown starting">10</div>
+        <p class="countdown-note">Counting down the final moments until the big day.</p>
       </div>
-    </main>
+    </div>
     <div class="border-cell right-tall" data-reveal-index="5"><img src="assets/images/AUG5177_bw.jpg" alt="Laughing in the field"></div>
 
     <div class="border-cell bottom-left" data-reveal-index="6"><img src="assets/images/AUG5106_bw.jpg" alt="Smiling under the trees"></div>


### PR DESCRIPTION
## Summary
- remove the outer content card wrapper from the border layout
- center the card shell directly within the grid area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cde6b98c18832eb38b0b4e3d693c45