### PR TITLE
Ensure countdown card maintains fixed dimensions

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -161,7 +161,8 @@ body {
   align-self: center;
   justify-self: center;
   width: min(560px, 100%);
-  min-height: clamp(320px, 58vw, 520px);
+  height: clamp(320px, 58vw, 520px);
+  max-height: 520px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -169,6 +170,7 @@ body {
 
 .card-shell > * {
   width: 100%;
+  height: 100%;
 }
 
 .countdown-wrapper {
@@ -184,7 +186,7 @@ body {
   text-align: center;
   gap: clamp(18px, 4vw, 30px);
   width: 100%;
-  min-height: inherit;
+  height: 100%;
 }
 
 .countdown-overlay {
@@ -290,6 +292,7 @@ body {
   gap: clamp(10px, 2.6vw, 18px);
   padding: clamp(16px, 3.6vw, 30px);
   justify-content: center;
+  align-items: stretch;
 }
 
 .countdown-wrapper.has-details {
@@ -326,19 +329,20 @@ body {
   width: 100%;
   border-radius: clamp(16px, 3vw, 28px);
   overflow: hidden;
-  aspect-ratio: 16 / 9;
   background: #000;
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
   border: 1.5px solid var(--card-border);
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .countdown-video {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- lock the countdown card container to a consistent height so each state keeps the same footprint
- stretch the countdown, video, and save-the-date layouts to fill the shell and let the video frame expand to the fixed size

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf1ce330c832ebf41202a89013774