### PR TITLE
Add celebratory reveal animation and effects

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -365,6 +365,50 @@ body {
   text-wrap: balance;
 }
 
+.save-date-title--spiral {
+  animation: spiralSpinIn 1.1s ease-out forwards;
+}
+
+.countdown-wrapper.has-details .eyebrow,
+.countdown-wrapper.has-details .save-date-date,
+.countdown-wrapper.has-details .save-date-note {
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.countdown-wrapper.has-details:not(.is-revealed) .eyebrow,
+.countdown-wrapper.has-details:not(.is-revealed) .save-date-date,
+.countdown-wrapper.has-details:not(.is-revealed) .save-date-note {
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+.countdown-wrapper.has-details.is-revealed .eyebrow,
+.countdown-wrapper.has-details.is-revealed .save-date-date,
+.countdown-wrapper.has-details.is-revealed .save-date-note {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes spiralSpinIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.2) rotate(-540deg);
+    filter: blur(6px);
+  }
+  55% {
+    opacity: 1;
+    transform: scale(1.08) rotate(18deg);
+    filter: blur(0);
+  }
+  75% {
+    transform: scale(0.96) rotate(-8deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}
+
 .save-date-title span {
   display: block;
   margin: 0;
@@ -403,6 +447,42 @@ body {
 
 .save-date-note {
   font-size: clamp(0.92rem, 2vw, 1.1rem);
+}
+
+.confetti-container {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 8;
+}
+
+.confetti-piece {
+  position: absolute;
+  width: clamp(8px, 1.2vw, 12px);
+  height: clamp(14px, 3vh, 18px);
+  border-radius: 2px;
+  top: -12vh;
+  left: var(--confetti-left, 50%);
+  transform: translate3d(calc(-50% + var(--confetti-drift, 0px)), 0, 0) rotate(0deg);
+  opacity: 0;
+  animation: confettiFall var(--confetti-duration, 3s) linear forwards;
+  animation-delay: var(--confetti-delay, 0s);
+  mix-blend-mode: screen;
+}
+
+@keyframes confettiFall {
+  0% {
+    opacity: 1;
+    transform: translate3d(calc(-50% + var(--confetti-drift, 0px)), -12vh, 0) rotate(0deg);
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(calc(-50% + var(--confetti-drift, 0px)), 110vh, 0) rotate(540deg);
+  }
 }
 
 .flip-card {

--- a/border.html
+++ b/border.html
@@ -67,6 +67,80 @@
       osc.stop(now + 0.34);
     };
 
+    const playBoom = () => {
+      if (!audioCtx) return;
+
+      if (audioCtx.state === 'suspended') {
+        audioCtx.resume().catch(() => {});
+      }
+
+      const now = audioCtx.currentTime;
+      const duration = 0.82;
+
+      const toneOscillator = audioCtx.createOscillator();
+      const toneGain = audioCtx.createGain();
+      toneOscillator.type = 'sine';
+      toneOscillator.frequency.setValueAtTime(180, now);
+      toneOscillator.frequency.exponentialRampToValueAtTime(52, now + duration);
+      toneGain.gain.setValueAtTime(0.0001, now);
+      toneGain.gain.exponentialRampToValueAtTime(1.1, now + 0.02);
+      toneGain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+      toneOscillator.connect(toneGain);
+      toneGain.connect(audioCtx.destination);
+
+      toneOscillator.start(now);
+      toneOscillator.stop(now + duration);
+
+      const noiseBuffer = audioCtx.createBuffer(1, Math.ceil(audioCtx.sampleRate * duration), audioCtx.sampleRate);
+      const noiseChannelData = noiseBuffer.getChannelData(0);
+      for (let i = 0; i < noiseChannelData.length; i += 1) {
+        const decay = 1 - i / noiseChannelData.length;
+        noiseChannelData[i] = (Math.random() * 2 - 1) * decay * decay;
+      }
+
+      const noiseSource = audioCtx.createBufferSource();
+      noiseSource.buffer = noiseBuffer;
+      const noiseGain = audioCtx.createGain();
+      noiseGain.gain.setValueAtTime(0.5, now);
+      noiseGain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+      noiseSource.connect(noiseGain);
+      noiseGain.connect(audioCtx.destination);
+
+      noiseSource.start(now);
+      noiseSource.stop(now + duration);
+    };
+
+    const launchConfetti = () => {
+      if (prefersReducedMotion) {
+        return;
+      }
+
+      if (!document.body) {
+        return;
+      }
+
+      const confettiContainer = document.createElement('div');
+      confettiContainer.className = 'confetti-container';
+      const colors = ['#ffe3a2', '#f6b8d1', '#95d5b2', '#7fd1ff', '#ffffff'];
+      const pieceCount = 80;
+
+      for (let index = 0; index < pieceCount; index += 1) {
+        const piece = document.createElement('span');
+        piece.className = 'confetti-piece';
+        piece.style.setProperty('--confetti-left', `${Math.random() * 100}%`);
+        piece.style.setProperty('--confetti-delay', `${Math.random() * 0.45}s`);
+        piece.style.setProperty('--confetti-duration', `${2.6 + Math.random()}s`);
+        piece.style.setProperty('--confetti-drift', `${Math.random() * 120 - 60}px`);
+        piece.style.backgroundColor = colors[index % colors.length];
+        confettiContainer.appendChild(piece);
+      }
+
+      document.body.appendChild(confettiContainer);
+      window.setTimeout(() => {
+        confettiContainer.remove();
+      }, 4200);
+    };
+
     const borderCells = Array.from(document.querySelectorAll('.border-cell')).sort((first, second) => {
       const firstIndex = Number(first.dataset.revealIndex) || 0;
       const secondIndex = Number(second.dataset.revealIndex) || 0;
@@ -110,7 +184,7 @@
       }
     };
 
-    const showSaveTheDateDetails = () => {
+    const showSaveTheDateDetails = ({ withCelebrateEffects = false } = {}) => {
       if (!cardShell) return;
       cardShell.innerHTML = '';
 
@@ -142,6 +216,23 @@
       wrapper.appendChild(note);
 
       cardShell.appendChild(wrapper);
+
+      if (withCelebrateEffects && !prefersReducedMotion) {
+        window.requestAnimationFrame(() => {
+          title.classList.add('save-date-title--spiral');
+        });
+
+        window.setTimeout(() => {
+          wrapper.classList.add('is-revealed');
+        }, 420);
+
+        window.setTimeout(() => {
+          playBoom();
+          launchConfetti();
+        }, 520);
+      } else {
+        wrapper.classList.add('is-revealed');
+      }
     };
 
     const showCelebrationVideo = () => {
@@ -167,7 +258,9 @@
       celebrationVideo.setAttribute('playsinline', '');
 
       celebrationVideo.addEventListener('ended', () => {
-        showSaveTheDateDetails();
+        window.setTimeout(() => {
+          showSaveTheDateDetails({ withCelebrateEffects: true });
+        }, 600);
       }, { once: true });
 
       celebrationVideo.addEventListener('error', () => {


### PR DESCRIPTION
## Summary
- add a spiral title animation, boom sound effect, and confetti burst when the save-the-date details appear
- delay the reveal briefly after the celebration video ends to emphasize the transition
- style the new animation states and confetti visuals for the bordered layout

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdf3c17074832ea829bcd704c48a18