### PR TITLE
Add mobile slideshow experience to border page

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -122,6 +122,12 @@ body {
     opacity: 1;
     transform: none;
   }
+
+  .mobile-frame {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .content-card {
@@ -171,6 +177,96 @@ body {
 .card-shell > * {
   width: 100%;
   height: 100%;
+}
+
+.mobile-experience {
+  display: none;
+  width: 100%;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 8vw, 40px);
+  background: var(--emerald-dark);
+}
+
+.mobile-stage {
+  width: 100%;
+  max-width: 560px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-inline: auto;
+  position: relative;
+}
+
+.mobile-frame {
+  width: 100%;
+  border-radius: clamp(20px, 6vw, 30px);
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.82);
+  box-shadow: 0 24px 52px rgba(0, 0, 0, 0.38);
+  opacity: 0;
+  transform: translateY(16px) scale(0.98);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.mobile-frame.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+.mobile-frame--photo {
+  aspect-ratio: 3 / 4;
+}
+
+.mobile-frame--photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mobile-frame--video {
+  aspect-ratio: 9 / 16;
+  background: #000;
+  display: flex;
+  align-items: stretch;
+}
+
+.mobile-frame--video .countdown-wrapper {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  align-items: stretch;
+  gap: 0;
+}
+
+.mobile-frame--video .video-hashtag {
+  display: none;
+}
+
+.mobile-frame--video .countdown-video-frame {
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  height: 100%;
+}
+
+.mobile-frame--video .countdown-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mobile-frame--card {
+  background: transparent;
+  box-shadow: none;
+}
+
+.mobile-frame--card .countdown-wrapper {
+  height: 100%;
+  justify-content: center;
 }
 
 .countdown-wrapper {
@@ -715,48 +811,32 @@ h1 {
   }
 
   .page-border {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: none;
-    grid-auto-rows: 1fr;
-    grid-template-areas: none;
-    height: 100vh;
-    min-height: 100vh;
-    padding: clamp(16px, 8vw, 34px);
-    gap: clamp(12px, 6vw, 24px);
-    align-content: start;
+    display: none;
   }
 
-  .page-border > * {
-    grid-area: auto !important;
+  .mobile-experience {
+    display: flex;
+    padding: clamp(24px, 12vw, 48px);
   }
 
-  .content-card {
-    grid-column: 1 / -1;
-    margin: 0;
-    padding: clamp(18px, 7vw, 34px);
+  .mobile-stage {
+    max-width: min(520px, 100%);
   }
 
-  .card-shell {
-    max-width: none;
-    width: 100%;
-    min-height: clamp(280px, 68vh, 480px);
+  .mobile-frame {
+    border-radius: clamp(22px, 10vw, 28px);
   }
 
-  .countdown-wrapper {
-    padding: clamp(22px, 7vw, 36px);
-    gap: clamp(16px, 6vw, 28px);
+  .mobile-frame--video {
+    aspect-ratio: 9 / 16;
   }
 
-  .countdown-wrapper.has-video {
-    max-width: 100%;
+  .mobile-frame--video .countdown-video-frame {
+    border-radius: clamp(18px, 8vw, 26px);
   }
 
-  .countdown-video-frame {
-    aspect-ratio: 4 / 3;
-  }
-
-  .border-cell {
-    border-radius: clamp(16px, 8vw, 24px);
+  .mobile-frame--card .countdown-wrapper {
+    padding: clamp(28px, 9vw, 42px);
   }
 }
 

--- a/border.html
+++ b/border.html
@@ -42,6 +42,9 @@
     <div class="border-cell bottom-wide" data-reveal-index="7"><img src="assets/images/AUG5127_bw.jpg" alt="Holding close"></div>
     <div class="border-cell bottom-right" data-reveal-index="8"><img src="assets/images/AUG5201_bw.jpg" alt="Strolling along the shoreline"></div>
   </div>
+  <div class="mobile-experience" id="mobileExperience" aria-live="polite" aria-label="Slideshow of our memories">
+    <div class="mobile-stage" id="mobileStage"></div>
+  </div>
   <script>
     const AudioContext = window.AudioContext || window.webkitAudioContext;
     const audioCtx = AudioContext ? new AudioContext() : null;
@@ -158,6 +161,33 @@
       });
     }
 
+    const mobileExperience = document.getElementById('mobileExperience');
+    const mobileStage = document.getElementById('mobileStage');
+    const mobileBreakpointQuery = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(max-width: 640px)')
+      : null;
+    let isMobileExperienceActive = mobileBreakpointQuery?.matches ?? false;
+
+    const updateMobileExperiencePreference = (event) => {
+      isMobileExperienceActive = event.matches;
+    };
+
+    if (mobileBreakpointQuery) {
+      if (typeof mobileBreakpointQuery.addEventListener === 'function') {
+        mobileBreakpointQuery.addEventListener('change', updateMobileExperiencePreference);
+      } else if (typeof mobileBreakpointQuery.addListener === 'function') {
+        mobileBreakpointQuery.addListener(updateMobileExperiencePreference);
+      }
+    }
+
+    const mobilePhotoDetails = borderCells.map((cell) => {
+      const cellImage = cell.querySelector('img');
+      return {
+        src: cellImage?.getAttribute('src') ?? '',
+        alt: cellImage?.getAttribute('alt') ?? '',
+      };
+    });
+
     const cardShell = document.getElementById('cardShell');
     const initialCountdownWrapper = cardShell?.querySelector('.countdown-wrapper');
     const countdownNumber = document.getElementById('countdownNumber');
@@ -173,7 +203,7 @@
     const startButton = document.getElementById('startCountdownButton');
 
     const revealNextBorderCell = () => {
-      if (prefersReducedMotion) {
+      if (prefersReducedMotion || isMobileExperienceActive) {
         return;
       }
 
@@ -184,10 +214,7 @@
       }
     };
 
-    const showSaveTheDateDetails = ({ withCelebrateEffects = false } = {}) => {
-      if (!cardShell) return;
-      cardShell.innerHTML = '';
-
+    const buildSaveTheDateDetails = () => {
       const wrapper = document.createElement('div');
       wrapper.className = 'countdown-wrapper has-details';
 
@@ -215,8 +242,10 @@
       wrapper.appendChild(dateLine);
       wrapper.appendChild(note);
 
-      cardShell.appendChild(wrapper);
+      return { wrapper, title };
+    };
 
+    const revealSaveTheDateDetails = ({ wrapper, title }, { withCelebrateEffects = false } = {}) => {
       if (withCelebrateEffects && !prefersReducedMotion) {
         window.requestAnimationFrame(() => {
           title.classList.add('save-date-title--spiral');
@@ -235,10 +264,19 @@
       }
     };
 
-    const showCelebrationVideo = () => {
-      if (!cardShell) return;
-      cardShell.innerHTML = '';
+    const showSaveTheDateDetails = ({
+      targetContainer = cardShell,
+      withCelebrateEffects = false,
+    } = {}) => {
+      if (!targetContainer) return;
 
+      const elements = buildSaveTheDateDetails();
+      targetContainer.innerHTML = '';
+      targetContainer.appendChild(elements.wrapper);
+      revealSaveTheDateDetails(elements, { withCelebrateEffects });
+    };
+
+    const buildCelebrationVideo = () => {
       const wrapper = document.createElement('div');
       wrapper.className = 'countdown-wrapper has-video';
 
@@ -257,22 +295,49 @@
       celebrationVideo.controls = true;
       celebrationVideo.setAttribute('playsinline', '');
 
-      celebrationVideo.addEventListener('ended', () => {
-        window.setTimeout(() => {
-          showSaveTheDateDetails({ withCelebrateEffects: true });
-        }, 600);
-      }, { once: true });
-
-      celebrationVideo.addEventListener('error', () => {
-        showSaveTheDateDetails();
-      }, { once: true });
-
       videoFrame.appendChild(celebrationVideo);
 
       wrapper.appendChild(videoHashtag);
       wrapper.appendChild(videoFrame);
 
-      cardShell.appendChild(wrapper);
+      return { wrapper, celebrationVideo };
+    };
+
+    const showCelebrationVideo = ({
+      targetContainer = cardShell,
+      onVideoEnded,
+      onVideoError,
+      withCelebrateEffectsOnComplete = true,
+    } = {}) => {
+      if (!targetContainer) return;
+
+      const { wrapper, celebrationVideo } = buildCelebrationVideo();
+      targetContainer.innerHTML = '';
+      targetContainer.appendChild(wrapper);
+
+      const resolvedOnEnded = typeof onVideoEnded === 'function'
+        ? onVideoEnded
+        : () => {
+            if (withCelebrateEffectsOnComplete) {
+              showSaveTheDateDetails({ targetContainer, withCelebrateEffects: true });
+            } else {
+              showSaveTheDateDetails({ targetContainer });
+            }
+          };
+
+      const resolvedOnError = typeof onVideoError === 'function'
+        ? onVideoError
+        : () => {
+            showSaveTheDateDetails({ targetContainer });
+          };
+
+      celebrationVideo.addEventListener('ended', () => {
+        window.setTimeout(resolvedOnEnded, 600);
+      }, { once: true });
+
+      celebrationVideo.addEventListener('error', () => {
+        resolvedOnError();
+      }, { once: true });
 
       const attemptVideoPlayback = () => {
         const playPromise = celebrationVideo.play();
@@ -286,6 +351,135 @@
       } else {
         celebrationVideo.addEventListener('canplay', attemptVideoPlayback, { once: true });
       }
+    };
+
+    const createMobileFrame = (additionalClassName = '') => {
+      const frame = document.createElement('div');
+      frame.className = `mobile-frame${additionalClassName ? ` ${additionalClassName}` : ''}`;
+      return frame;
+    };
+
+    const swapMobileFrame = (newFrame) => {
+      if (!mobileStage) {
+        return;
+      }
+
+      const transitionDelay = prefersReducedMotion ? 0 : 520;
+      const existingFrame = mobileStage.firstElementChild;
+
+      const placeNewFrame = () => {
+        mobileStage.replaceChildren(newFrame);
+        if (prefersReducedMotion) {
+          newFrame.classList.add('is-visible');
+        } else {
+          window.requestAnimationFrame(() => {
+            newFrame.classList.add('is-visible');
+          });
+        }
+      };
+
+      if (existingFrame && !prefersReducedMotion) {
+        existingFrame.classList.remove('is-visible');
+        window.setTimeout(placeNewFrame, transitionDelay);
+      } else {
+        placeNewFrame();
+      }
+    };
+
+    const showMobileSaveTheDate = ({ withCelebrateEffects = true } = {}) => {
+      if (!mobileStage) {
+        return;
+      }
+
+      const elements = buildSaveTheDateDetails();
+      const frame = createMobileFrame('mobile-frame--card');
+      frame.appendChild(elements.wrapper);
+
+      swapMobileFrame(frame);
+
+      const reveal = () => {
+        revealSaveTheDateDetails(elements, { withCelebrateEffects });
+      };
+
+      if (prefersReducedMotion) {
+        reveal();
+      } else {
+        window.setTimeout(reveal, 80);
+      }
+    };
+
+    const showMobileVideo = () => {
+      if (!mobileStage) {
+        return;
+      }
+
+      const { wrapper, celebrationVideo } = buildCelebrationVideo();
+      const frame = createMobileFrame('mobile-frame--video');
+      frame.appendChild(wrapper);
+
+      swapMobileFrame(frame);
+
+      celebrationVideo.addEventListener('ended', () => {
+        window.setTimeout(() => {
+          showMobileSaveTheDate({ withCelebrateEffects: true });
+        }, 600);
+      }, { once: true });
+
+      celebrationVideo.addEventListener('error', () => {
+        showMobileSaveTheDate({ withCelebrateEffects: false });
+      }, { once: true });
+
+      const attemptVideoPlayback = () => {
+        const playPromise = celebrationVideo.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(() => {});
+        }
+      };
+
+      if (celebrationVideo.readyState >= 2) {
+        attemptVideoPlayback();
+      } else {
+        celebrationVideo.addEventListener('canplay', attemptVideoPlayback, { once: true });
+      }
+    };
+
+    const showMobilePhotoAtIndex = (index) => {
+      if (!mobileStage) {
+        return;
+      }
+
+      const photoDetails = mobilePhotoDetails[index];
+      if (!photoDetails || !photoDetails.src) {
+        showMobileVideo();
+        return;
+      }
+
+      const frame = createMobileFrame('mobile-frame--photo');
+      const image = document.createElement('img');
+      image.src = photoDetails.src;
+      image.alt = photoDetails.alt || '';
+      frame.appendChild(image);
+
+      swapMobileFrame(frame);
+
+      const displayDuration = prefersReducedMotion ? 1600 : 2800;
+      window.setTimeout(() => {
+        showMobilePhotoAtIndex(index + 1);
+      }, displayDuration);
+    };
+
+    const startMobileSequence = () => {
+      if (!mobileStage) {
+        showCelebrationVideo({ targetContainer: cardShell });
+        return;
+      }
+
+      if (mobilePhotoDetails.length === 0) {
+        showMobileVideo();
+        return;
+      }
+
+      showMobilePhotoAtIndex(0);
     };
     const handleCountdownTick = () => {
       if (!countdownNumber) {
@@ -319,6 +513,11 @@
     };
 
     const startCountdownFlow = () => {
+      if (isMobileExperienceActive) {
+        startMobileSequence();
+        return;
+      }
+
       if (!countdownNumber || !initialCountdownWrapper) {
         showCelebrationVideo();
         return;
@@ -353,7 +552,11 @@
         audioCtx.resume().catch(() => {});
       }
 
-      startCountdownFlow();
+      if (isMobileExperienceActive) {
+        startMobileSequence();
+      } else {
+        startCountdownFlow();
+      }
     };
 
     const handleOverlayKeyDown = (event) => {


### PR DESCRIPTION
## Summary
- add a mobile-only slideshow container that fades in each border photo sequentially
- show the celebration video and save-the-date card full screen on small screens after the slideshow finishes
- refactor shared countdown helpers to support both desktop and mobile experiences and update responsive styles

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cdfcc6ef40832e8daf6545dfeb4516