### PR TITLE
Speed up mobile slideshow and restore reveal audio

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -176,7 +176,7 @@ body {
   box-shadow: 0 24px 52px rgba(0, 0, 0, 0.38);
   opacity: 0;
   transform: translateY(16px) scale(0.98);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transition: opacity 0.45s ease, transform 0.45s ease;
 }
 
 .mobile-frame.is-visible {

--- a/index.html
+++ b/index.html
@@ -491,9 +491,10 @@
       image.alt = photoDetails.alt || '';
       frame.appendChild(image);
 
+      playBeat();
       swapMobileFrame(frame);
 
-      const displayDuration = prefersReducedMotion ? 1600 : 2800;
+      const displayDuration = prefersReducedMotion ? 1600 : 2000;
       window.setTimeout(() => {
         showMobilePhotoAtIndex(index + 1);
       }, displayDuration);


### PR DESCRIPTION
## Summary
- play the countdown beat whenever mobile slideshow photos reveal so the audio matches the desktop experience
- shorten the mobile photo display duration and transition timing for a snappier animation on phones

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce617cabac832e98bf8f0a4d3627f0