### PR TITLE
Ensure mobile layout applies to short viewports

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -565,7 +565,7 @@ h1 {
 
 }
 
-@media (max-width: 640px) {
+@media (max-width: 640px), (max-height: 520px) {
   body {
     display: block;
     overflow-y: auto;

--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
     const mobileExperience = document.getElementById('mobileExperience');
     const mobileStage = document.getElementById('mobileStage');
     const mobileBreakpointQuery = typeof window.matchMedia === 'function'
-      ? window.matchMedia('(max-width: 640px)')
+      ? window.matchMedia('(max-width: 640px), (max-height: 520px)')
       : null;
     let isMobileExperienceActive = mobileBreakpointQuery?.matches ?? false;
 


### PR DESCRIPTION
## Summary
- treat short landscape viewports as mobile in both CSS and JavaScript breakpoint logic
- ensure the simplified mobile layout is used consistently on small devices regardless of orientation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce62632184832ea2668740315ce289