### PR TITLE
Ensure mobile layouts use full viewport and add rotate prompt

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -17,6 +17,7 @@
 
 html, body {
   height: 100%;
+  min-height: 100%;
   margin: 0;
 }
 
@@ -28,6 +29,8 @@ body {
   align-items: stretch;
   justify-content: stretch;
   min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
 }
 
 .page-border {
@@ -42,6 +45,9 @@ body {
   gap: 0;
   width: 100%;
   height: 100vh;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
   overflow: hidden;
   padding: 0;
 }
@@ -152,6 +158,8 @@ body {
   display: none;
   width: 100%;
   min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
   align-items: center;
   justify-content: center;
   padding: clamp(24px, 8vw, 40px);
@@ -161,6 +169,7 @@ body {
 .mobile-stage {
   width: 100%;
   max-width: 560px;
+  min-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -177,11 +186,20 @@ body {
   opacity: 0;
   transform: translateY(16px) scale(0.98);
   transition: opacity 0.45s ease, transform 0.45s ease;
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
 }
 
 .mobile-frame.is-visible {
   opacity: 1;
   transform: none;
+}
+
+.mobile-frame > * {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .mobile-frame--photo {
@@ -252,6 +270,7 @@ body {
   gap: clamp(18px, 4vw, 30px);
   width: 100%;
   height: 100%;
+  min-height: 0;
 }
 
 .countdown-overlay {
@@ -268,6 +287,39 @@ body {
   letter-spacing: 0.2em;
   transition: opacity 0.6s ease;
   overflow: hidden;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+}
+
+.orientation-prompt {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 8vw, 40px);
+  background: rgba(3, 40, 28, 0.88);
+  color: var(--cream);
+  text-align: center;
+  font-family: var(--countdown-font);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: clamp(1rem, 3.6vw, 1.5rem);
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 2;
+}
+
+.orientation-prompt.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.orientation-prompt__text {
+  max-width: 28ch;
 }
 
 .countdown-overlay.start-prompt {
@@ -579,6 +631,7 @@ h1 {
     display: flex;
     width: 100vw;
     min-height: 100vh;
+    min-height: 100svh;
     min-height: 100dvh;
     padding: 0;
     align-items: stretch;
@@ -587,6 +640,7 @@ h1 {
   .mobile-stage {
     max-width: none;
     height: 100%;
+    min-height: 100%;
     flex: 1 1 auto;
     align-items: stretch;
     justify-content: stretch;
@@ -598,7 +652,6 @@ h1 {
     height: 100%;
     width: 100%;
     box-shadow: none;
-    display: flex;
   }
 
   .mobile-frame--photo,

--- a/index.html
+++ b/index.html
@@ -220,6 +220,71 @@
     let revealedCells = 0;
     let countdownIntervalId = null;
     let hasStarted = false;
+    let tearDownOrientationPrompt = null;
+
+    const clearOrientationPrompt = () => {
+      if (typeof tearDownOrientationPrompt === 'function') {
+        tearDownOrientationPrompt();
+        tearDownOrientationPrompt = null;
+      }
+    };
+
+    const setupOrientationPrompt = ({ container, video }) => {
+      if (!container || !video) {
+        return () => {};
+      }
+
+      const prompt = document.createElement('div');
+      prompt.className = 'orientation-prompt';
+      prompt.setAttribute('role', 'status');
+      prompt.setAttribute('aria-live', 'polite');
+      prompt.setAttribute('aria-hidden', 'true');
+
+      const promptText = document.createElement('span');
+      promptText.className = 'orientation-prompt__text';
+      promptText.textContent = 'Rotate your device to watch in full screen';
+
+      prompt.appendChild(promptText);
+      container.appendChild(prompt);
+
+      const updatePromptVisibility = () => {
+        const viewportWidth = window.innerWidth || 0;
+        const viewportHeight = window.innerHeight || 0;
+        const isViewportPortrait = viewportHeight > viewportWidth;
+        const hasMetadata = video.videoWidth > 0 && video.videoHeight > 0;
+        const isVideoLandscape = hasMetadata ? video.videoWidth >= video.videoHeight : false;
+
+        if (isViewportPortrait && isVideoLandscape) {
+          prompt.classList.add('is-visible');
+          prompt.setAttribute('aria-hidden', 'false');
+        } else {
+          prompt.classList.remove('is-visible');
+          prompt.setAttribute('aria-hidden', 'true');
+        }
+      };
+
+      const handleLoadedMetadata = () => {
+        updatePromptVisibility();
+      };
+
+      video.addEventListener('loadedmetadata', handleLoadedMetadata);
+      window.addEventListener('resize', updatePromptVisibility);
+      window.addEventListener('orientationchange', updatePromptVisibility);
+
+      window.setTimeout(updatePromptVisibility, 0);
+
+      return () => {
+        prompt.remove();
+        video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+        window.removeEventListener('resize', updatePromptVisibility);
+        window.removeEventListener('orientationchange', updatePromptVisibility);
+      };
+    };
+
+    const applyOrientationPrompt = ({ container, video }) => {
+      clearOrientationPrompt();
+      tearDownOrientationPrompt = setupOrientationPrompt({ container, video });
+    };
 
     const startOverlay = document.getElementById('startOverlay');
     const startOverlayContent = startOverlay?.querySelector('.countdown-overlay-content') ?? null;
@@ -406,6 +471,8 @@
         return;
       }
 
+      clearOrientationPrompt();
+
       const transitionDelay = prefersReducedMotion ? 0 : 520;
       const existingFrame = mobileStage.firstElementChild;
 
@@ -460,6 +527,8 @@
       frame.appendChild(wrapper);
 
       swapMobileFrame(frame);
+
+      applyOrientationPrompt({ container: frame, video: celebrationVideo });
 
       celebrationVideo.addEventListener('ended', () => {
         window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure the mobile and desktop shells stretch to the safe viewport height using dynamic viewport units
- let mobile frames and save-the-date card fill the screen consistently across devices
- add a rotation prompt that asks users to rotate when the celebration video is landscape on a portrait device

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ced8ff0bec832eaeaa334aef68150e