### PR TITLE
Keep countdown note constant at completion

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,7 +660,7 @@
           window.clearInterval(countdownIntervalId);
           revealNextBorderCell();
           if (countdownNote) {
-            countdownNote.textContent = "It's time to celebrate!";
+            countdownNote.textContent = 'Counting down the final moments until the big day.';
           }
           window.setTimeout(() => {
             showCelebrationVideo();


### PR DESCRIPTION
## Summary
- prevent the countdown note from switching to the "It's time to celebrate!" message when the timer reaches zero
- ensure the note continues to display "Counting down the final moments until the big day." throughout the experience

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef1026480832eb0d4d88c5b099ea6