### PR TITLE
Adjust confetti palette to theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       // Configuration constants that define animation timing and interaction behavior.
       const KEYBOARD_ACTIVATION_KEYS = new Set(['Enter', ' ', 'Spacebar']);
       const CELEBRATION_CONFETTI_PIECES = 80;
-      const CELEBRATION_CONFETTI_COLORS = ['#ffe3a2', '#f6b8d1', '#95d5b2', '#7fd1ff', '#ffffff'];
+      const CELEBRATION_CONFETTI_COLORS = ['#03281c', '#000000', '#ffffff'];
       const CELEBRATION_CONFETTI_LIFETIME_MS = 4200;
       const CELEBRATION_TRANSITION_DELAY_MS = 520;
       const VIDEO_COMPLETE_DELAY_MS = 600;


### PR DESCRIPTION
## Summary
- limit the celebration confetti colors to the site's emerald background, black, and white for a cohesive palette

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cef1d50118832eb6b35387c0292cb2