### PR TITLE
Improve sneak peek back button contrast

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -685,6 +685,21 @@ body {
 
 .sneak-peek-wrapper .save-date-back-button {
   margin-top: clamp(4px, 1.6vw, 12px);
+  color: var(--cream);
+  border-color: rgba(245, 241, 235, 0.6);
+  background: rgba(245, 241, 235, 0.08);
+}
+
+.sneak-peek-wrapper .save-date-back-button .save-date-action__icon {
+  background: rgba(245, 241, 235, 0.2);
+  color: var(--emerald-dark);
+}
+
+.sneak-peek-wrapper .save-date-back-button:hover,
+.sneak-peek-wrapper .save-date-back-button:focus-visible {
+  background: rgba(245, 241, 235, 0.18);
+  border-color: rgba(245, 241, 235, 0.82);
+  box-shadow: 0 12px 26px rgba(3, 40, 28, 0.32);
 }
 
 .confetti-container {


### PR DESCRIPTION
## Summary
- lighten the sneak peek video back button text and icon treatment for better contrast
- update hover and focus styles to keep the button legible against the dark video background

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf485b18e4832e847d70e8cc90736a