### PR TITLE
Improve sneak peek back button contrast

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -685,7 +685,7 @@ body {
 
 .sneak-peek-wrapper .save-date-back-button {
   margin-top: clamp(4px, 1.6vw, 12px);
-  color: var(--cream);
+  color: var(--emerald-dark);
   border-color: rgba(245, 241, 235, 0.6);
   background: rgba(245, 241, 235, 0.08);
 }
@@ -825,6 +825,20 @@ h1 {
     border-radius: 0;
     box-shadow: none;
     border: none;
+  }
+
+  .mobile-frame--video .sneak-peek-wrapper .countdown-note {
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .mobile-frame--video .sneak-peek-wrapper .save-date-back-button {
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.7);
+  }
+
+  .mobile-frame--video .sneak-peek-wrapper .save-date-back-button .save-date-action__icon {
+    background: rgba(255, 255, 255, 0.22);
+    color: var(--emerald-dark);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the sneak peek back button color to remain readable on the desktop card view
- add mobile-specific overrides so the sneak peek caption and back button stay visible over the dark video background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf5844cfe8832ea58d36b8e583648d