### PR TITLE
Adjust back to details border on desktop

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -686,7 +686,7 @@ body {
 .sneak-peek-wrapper .save-date-back-button {
   margin-top: clamp(4px, 1.6vw, 12px);
   color: var(--emerald-dark);
-  border-color: rgba(245, 241, 235, 0.6);
+  border-color: var(--emerald-mid);
   background: rgba(245, 241, 235, 0.08);
 }
 
@@ -698,7 +698,7 @@ body {
 .sneak-peek-wrapper .save-date-back-button:hover,
 .sneak-peek-wrapper .save-date-back-button:focus-visible {
   background: rgba(245, 241, 235, 0.18);
-  border-color: rgba(245, 241, 235, 0.82);
+  border-color: var(--emerald-dark);
   box-shadow: 0 12px 26px rgba(3, 40, 28, 0.32);
 }
 


### PR DESCRIPTION
## Summary
- update the back to details button styling so the default desktop view uses an emerald border and hover state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf5a6af36c832ebce65c243e3bb507