### PR TITLE
Add wedding website link to save-the-date card

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -549,7 +549,8 @@ body {
   flex-direction: column;
   align-items: center;
   gap: clamp(10px, 2.4vw, 16px);
-  width: 100%;
+  width: min(100%, 640px);
+  margin-inline: auto;
 }
 
 .save-date-action {
@@ -648,10 +649,12 @@ body {
   .save-date-actions {
     flex-direction: row;
     justify-content: center;
+    flex-wrap: wrap;
+    gap: clamp(12px, 2.2vw, 18px);
   }
 
   .save-date-action {
-    min-width: auto;
+    min-width: clamp(180px, 32%, 240px);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -469,9 +469,20 @@
         iconPath,
         additionalClassName = '',
         viewBox = '0 0 24 24',
+        element = 'button',
+        href = '',
       }) => {
-        const button = document.createElement('button');
-        button.type = 'button';
+        const tagName = element === 'a' ? 'a' : 'button';
+        const button = document.createElement(tagName);
+        if (tagName === 'button') {
+          button.type = 'button';
+        } else if (href) {
+          button.href = href;
+          button.target = '_blank';
+          button.rel = 'noopener noreferrer';
+        } else {
+          button.href = '#';
+        }
         button.className = `save-date-action${
           additionalClassName ? ` ${additionalClassName}` : ''
         }`;
@@ -543,6 +554,14 @@
         const actions = document.createElement('div');
         actions.className = 'save-date-actions';
 
+        const websiteLink = createSaveTheDateActionButton({
+          label: 'Wedding website',
+          iconPath: 'M12 4a4 4 0 0 1 4 4v1h1a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H8a3 3 0 0 1-3-3v-6a3 3 0 0 1 3-3h1V8a4 4 0 0 1 4-4zm0 2a2 2 0 0 0-2 2v1h4V8a2 2 0 0 0-2-2zm5 5H8a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1z',
+          element: 'a',
+          href: 'https://becomingcummings.love',
+        });
+        websiteLink.setAttribute('aria-label', 'Visit our wedding website (opens in a new tab)');
+
         const replayButton = createSaveTheDateActionButton({
           label: 'Replay celebration video',
           iconPath:
@@ -557,7 +576,7 @@
         });
         sneakPeekButton.setAttribute('aria-label', 'Play the venue sneak peek video');
 
-        actions.append(replayButton, sneakPeekButton);
+        actions.append(websiteLink, replayButton, sneakPeekButton);
 
         wrapper.appendChild(eyebrow);
         wrapper.appendChild(title);
@@ -565,7 +584,7 @@
         wrapper.appendChild(note);
         wrapper.appendChild(actions);
 
-        return { wrapper, title, replayButton, sneakPeekButton };
+        return { wrapper, title, replayButton, sneakPeekButton, websiteLink };
       };
 
       const revealSaveTheDateDetails = ({ title }, { withCelebrateEffects = false } = {}) => {


### PR DESCRIPTION
## Summary
- add a dedicated wedding website link within the save-the-date actions
- enhance the shared action builder to support anchor elements and open the site in a new tab
- refine action layout spacing so the new link fits cleanly across screen sizes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf6e242bb0832e8f322bc39b80cbc3