### PR TITLE
Update mobile viewport sizing to use dynamic viewport units

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -155,9 +155,8 @@ body {
 .mobile-experience {
   display: none;
   width: 100%;
-  min-height: 100vh;
-  min-height: 100svh;
   min-height: 100dvh;
+  height: 100dvh;
   align-items: center;
   justify-content: center;
   padding: clamp(24px, 8vw, 40px);
@@ -167,7 +166,8 @@ body {
 .mobile-stage {
   width: 100%;
   max-width: 560px;
-  min-height: 100%;
+  min-height: 100dvh;
+  height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -188,6 +188,8 @@ body {
   display: flex;
   align-items: stretch;
   justify-content: stretch;
+  min-height: 100dvh;
+  height: 100dvh;
 }
 
 .mobile-frame.is-visible {
@@ -205,8 +207,8 @@ body {
 }
 
 .mobile-frame--photo img {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100dvh;
   object-fit: cover;
   display: block;
 }
@@ -239,9 +241,10 @@ body {
 }
 
 .mobile-frame--video .countdown-video {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100dvh;
   object-fit: cover;
+  display: block;
 }
 
 .mobile-frame--card {
@@ -789,17 +792,16 @@ h1 {
   .mobile-experience {
     display: flex;
     width: 100vw;
-    min-height: 100vh;
-    min-height: 100svh;
     min-height: 100dvh;
+    height: 100dvh;
     padding: 0;
     align-items: stretch;
   }
 
   .mobile-stage {
     max-width: none;
-    height: 100%;
-    min-height: 100%;
+    height: 100dvh;
+    min-height: 100dvh;
     flex: 1 1 auto;
     align-items: stretch;
     justify-content: stretch;
@@ -808,8 +810,9 @@ h1 {
 
   .mobile-frame {
     border-radius: 0;
-    height: 100%;
-    width: 100%;
+    height: 100dvh;
+    min-height: 100dvh;
+    width: 100vw;
     box-shadow: none;
   }
 


### PR DESCRIPTION
## Summary
- update mobile experience, stage, and frame containers to rely on 100dvh for full-height layouts
- ensure mobile media query overrides also use 100dvh and 100vw for viewport-filling sizing
- size mobile frame imagery and video to 100vw by 100dvh with object-fit cover and block display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf70fe0eac832eabb4af8107353974