### PR TITLE
Remove mobile orientation prompt

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -293,36 +293,6 @@ body {
   min-height: 100dvh;
 }
 
-.orientation-prompt {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(24px, 8vw, 40px);
-  background: rgba(3, 40, 28, 0.88);
-  color: var(--cream);
-  text-align: center;
-  font-family: var(--countdown-font);
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: clamp(1rem, 3.6vw, 1.5rem);
-  line-height: 1.4;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-  z-index: 2;
-}
-
-.orientation-prompt.is-visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.orientation-prompt__text {
-  max-width: 28ch;
-}
-
 .countdown-overlay.start-prompt {
   cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -379,72 +379,11 @@
       let revealedCells = 0;
       let countdownIntervalId = null;
       let hasStarted = false;
-      let tearDownOrientationPrompt = null;
 
       // Orientation prompts -----------------------------------------------
-      const clearOrientationPrompt = () => {
-        if (typeof tearDownOrientationPrompt === 'function') {
-          tearDownOrientationPrompt();
-          tearDownOrientationPrompt = null;
-        }
-      };
+      const clearOrientationPrompt = () => {};
 
-      const setupOrientationPrompt = ({ container, video }) => {
-        if (!container || !video) {
-          return () => {};
-        }
-
-        const prompt = document.createElement('div');
-        prompt.className = 'orientation-prompt';
-        prompt.setAttribute('role', 'status');
-        prompt.setAttribute('aria-live', 'polite');
-        prompt.setAttribute('aria-hidden', 'true');
-
-        const promptText = document.createElement('span');
-        promptText.className = 'orientation-prompt__text';
-        promptText.textContent = 'Rotate your device to watch in full screen';
-
-        prompt.appendChild(promptText);
-        container.appendChild(prompt);
-
-        const updatePromptVisibility = () => {
-          const viewportWidth = window.innerWidth || 0;
-          const viewportHeight = window.innerHeight || 0;
-          const isViewportPortrait = viewportHeight > viewportWidth;
-          const hasMetadata = video.videoWidth > 0 && video.videoHeight > 0;
-          const isVideoLandscape = hasMetadata ? video.videoWidth >= video.videoHeight : false;
-
-          if (isViewportPortrait && isVideoLandscape) {
-            prompt.classList.add('is-visible');
-            prompt.setAttribute('aria-hidden', 'false');
-          } else {
-            prompt.classList.remove('is-visible');
-            prompt.setAttribute('aria-hidden', 'true');
-          }
-        };
-
-        const handleLoadedMetadata = () => {
-          updatePromptVisibility();
-        };
-
-        video.addEventListener('loadedmetadata', handleLoadedMetadata);
-        window.addEventListener('resize', updatePromptVisibility);
-        window.addEventListener('orientationchange', updatePromptVisibility);
-
-        window.setTimeout(updatePromptVisibility, 0);
-
-        return () => {
-          prompt.remove();
-          video.removeEventListener('loadedmetadata', handleLoadedMetadata);
-          window.removeEventListener('resize', updatePromptVisibility);
-          window.removeEventListener('orientationchange', updatePromptVisibility);
-        };
-      };
-
-      const applyOrientationPrompt = ({ container, video }) => {
-        clearOrientationPrompt();
-        tearDownOrientationPrompt = setupOrientationPrompt({ container, video });
-      };
+      const applyOrientationPrompt = () => {};
 
       // Overlay controls --------------------------------------------------
       const startOverlay = document.getElementById('startOverlay');


### PR DESCRIPTION
## Summary
- remove the JavaScript hook that injected the mobile "rotate your device" notice
- delete the unused orientation prompt styles so no overlay can appear

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf729eea4c832e83068c1085b97cb3