### PR TITLE
Ensure mobile photo transitions allow frame visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
       const SAVE_THE_DATE_REVEAL_DELAY_MS = 80;
       const COUNTDOWN_START_FALLBACK = 10;
       const MOBILE_PHOTO_DEFAULT_DURATION_MS = 1600;
+      const MOBILE_PHOTO_TRANSITION_BUFFER_MS = 80;
       const MOBILE_PHOTO_CYCLE_DURATIONS = [
         { start: 2000, step: 140, min: 1200 },
         { start: 1100, step: 160, min: 420 },
@@ -879,10 +880,16 @@
         playBeat();
         swapMobileFrame(frame);
 
+        const transitionDelay = prefersReducedMotion ? 0 : CELEBRATION_TRANSITION_DELAY_MS;
         const displayDuration = getMobilePhotoDisplayDuration({ cycleIndex, photoIndex: index });
+        const minimumDelay = transitionDelay > 0
+          ? transitionDelay + MOBILE_PHOTO_TRANSITION_BUFFER_MS
+          : 0;
+        const scheduleDelay = Math.max(displayDuration, minimumDelay);
+
         window.setTimeout(() => {
           showMobilePhotoAtIndex(index + 1, cycleIndex);
-        }, displayDuration);
+        }, scheduleDelay);
       };
 
       const startMobileSequence = () => {


### PR DESCRIPTION
## Summary
- add a buffer to the mobile photo timing to prevent the next frame from triggering before the transition completes
- keep the slideshow beat consistent by ensuring each frame remains visible long enough to avoid the off-beat flash

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf77243790832e89da99568cdb2d7a