### PR TITLE
Ensure card renders above border photos

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -56,6 +56,7 @@ body {
   position: relative;
   overflow: hidden;
   isolation: isolate;
+  z-index: 1;
   opacity: 0;
   transform: translateY(24px) scale(0.94);
   transition: opacity 0.9s ease, transform 0.9s ease;
@@ -146,6 +147,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 2;
 }
 
 .card-shell > * {


### PR DESCRIPTION
## Summary
- ensure border photos render under the central card on desktop layouts by setting explicit stacking order

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf783e8ad8832e94eab8e37e383678