### PR TITLE
Adjust calendar invite icon placement

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -410,20 +410,27 @@ body {
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
   padding: clamp(26px, 4.4vw, 42px);
   gap: clamp(12px, 3vw, 20px);
-  align-items: center;
+  align-items: flex-start;
+  text-align: left;
   position: relative;
 }
 
+.save-date-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: clamp(10px, 2.4vw, 16px);
+  width: 100%;
+}
+
 .save-date-calendar {
-  position: absolute;
-  top: clamp(16px, 3.6vw, 28px);
-  right: clamp(16px, 3.6vw, 28px);
-  text-align: left;
+  position: relative;
+  display: inline-flex;
 }
 
 .save-date-calendar-details {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
 }
 
 .save-date-calendar-summary {
@@ -431,20 +438,18 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  background: var(--emerald-mid);
-  color: var(--cream);
-  font-weight: 600;
-  font-size: clamp(0.8rem, 1.8vw, 1rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  border-radius: 999px;
-  padding: 0.55em 1.4em 0.5em;
+  width: clamp(38px, 4vw, 44px);
+  height: clamp(38px, 4vw, 44px);
+  border-radius: 50%;
+  background: rgba(12, 63, 43, 0.12);
+  color: var(--emerald-mid);
+  border: 1px solid rgba(12, 44, 29, 0.18);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
   cursor: pointer;
-  transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+  transition: background var(--transition), transform var(--transition), box-shadow var(--transition), color var(--transition);
   user-select: none;
+  position: relative;
+  padding: 0;
 }
 
 .save-date-calendar-summary::-webkit-details-marker {
@@ -452,8 +457,8 @@ body {
 }
 
 .save-date-calendar-details[open] .save-date-calendar-summary {
-  background: var(--emerald-dark);
-  transform: translateY(1px);
+  background: rgba(12, 63, 43, 0.2);
+  color: var(--emerald-dark);
 }
 
 .save-date-calendar-summary:focus-visible {
@@ -461,10 +466,48 @@ body {
   outline-offset: 4px;
 }
 
+.save-date-calendar-summary::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translate3d(0, -50%, 0);
+  background: rgba(12, 44, 29, 0.92);
+  color: var(--cream);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: clamp(0.6rem, 1.4vw, 0.75rem);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.22);
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.save-date-calendar-details:hover .save-date-calendar-summary::after,
+.save-date-calendar-details:focus-within .save-date-calendar-summary::after,
+.save-date-calendar-details[open] .save-date-calendar-summary::after {
+  opacity: 1;
+  transform: translate3d(8px, -50%, 0);
+}
+
+.save-date-calendar-icon {
+  display: inline-flex;
+  width: clamp(18px, 2.4vw, 22px);
+  height: clamp(18px, 2.4vw, 22px);
+}
+
+.save-date-calendar-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
 .save-date-calendar-menu {
   position: absolute;
   top: calc(100% + 14px);
-  right: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -475,10 +518,18 @@ body {
   border: 1px solid rgba(12, 44, 29, 0.18);
   min-width: clamp(220px, 32vw, 240px);
   z-index: 4;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, 8px, 0);
+  transition: opacity var(--transition), transform var(--transition);
 }
 
-.save-date-calendar-details:not([open]) .save-date-calendar-menu {
-  display: none;
+.save-date-calendar-details:hover .save-date-calendar-menu,
+.save-date-calendar-details:focus-within .save-date-calendar-menu,
+.save-date-calendar-details[open] .save-date-calendar-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
 }
 
 .save-date-calendar-link {
@@ -505,21 +556,19 @@ body {
 @media (max-width: 680px) {
   .save-date-calendar {
     position: static;
-    width: 100%;
-    display: flex;
-    justify-content: center;
   }
 
   .save-date-calendar-details {
     display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 
   .save-date-calendar-menu {
     position: static;
     width: min(100%, 320px);
     margin-top: 14px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -761,17 +761,7 @@
       summary.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     };
 
-    details.addEventListener('mouseenter', () => {
-      details.open = true;
-      setExpanded(true);
-    });
-
-    details.addEventListener('mouseleave', () => {
-      details.open = false;
-      setExpanded(false);
-      summary.blur();
-    });
-
+    // Removed mouseenter and mouseleave event listeners for accessibility compliance.
     summary.addEventListener('focus', () => {
       details.open = true;
       setExpanded(true);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -724,8 +724,20 @@
 
     const summary = document.createElement('summary');
     summary.className = 'save-date-calendar-summary';
-    summary.textContent = 'Add to calendar';
     summary.setAttribute('aria-label', 'Add the wedding weekend to your calendar');
+    summary.setAttribute('aria-expanded', 'false');
+    summary.setAttribute('title', 'Add to calendar');
+    summary.dataset.tooltip = 'Add to calendar';
+
+    const icon = document.createElement('span');
+    icon.className = 'save-date-calendar-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.innerHTML =
+      '<svg width="24" height="24" viewBox="0 0 24 24" role="img" focusable="false">' +
+      '<path fill="currentColor" d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h1V3a1 1 0 0 1 1-1zm13 6H4v10a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1zm-5 3a1 1 0 0 1 1 1v3h-6v-3a1 1 0 0 1 1-1z"></path>' +
+      '</svg>';
+
+    summary.appendChild(icon);
 
     const menu = document.createElement('div');
     menu.className = 'save-date-calendar-menu';
@@ -745,7 +757,35 @@
     details.append(summary, menu);
     container.append(details);
 
+    const setExpanded = (expanded) => {
+      summary.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    };
+
+    details.addEventListener('mouseenter', () => {
+      details.open = true;
+      setExpanded(true);
+    });
+
+    details.addEventListener('mouseleave', () => {
+      details.open = false;
+      setExpanded(false);
+      summary.blur();
+    });
+
+    summary.addEventListener('focus', () => {
+      details.open = true;
+      setExpanded(true);
+    });
+
+    details.addEventListener('focusout', (event) => {
+      if (!details.contains(event.relatedTarget)) {
+        details.open = false;
+        setExpanded(false);
+      }
+    });
+
     details.addEventListener('toggle', () => {
+      setExpanded(details.open);
       if (!details.open) {
         summary.blur();
       }
@@ -782,9 +822,12 @@
     const calendarControls = createCalendarInviteControls();
     const { actions, websiteLink, replayButton, sneakPeekButton } = createSaveTheDateActions();
 
+    const header = document.createElement('div');
+    header.className = 'save-date-header';
+    header.append(calendarControls.container, eyebrow);
+
     // Assemble the interface
-    wrapper.appendChild(calendarControls.container);
-    wrapper.appendChild(eyebrow);
+    wrapper.appendChild(header);
     wrapper.appendChild(title);
     wrapper.appendChild(dateLine);
     wrapper.appendChild(note);


### PR DESCRIPTION
## Summary
- move the calendar invite control into the save the date header with an icon-only trigger and hover/focus behaviors
- restyle the calendar menu to open from the top-left corner with tooltip messaging and smooth transitions

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfb284277c832e8f67db127cd2d957