### PR TITLE
Center date and invite details text

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -708,6 +708,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: clamp(4px, 1vw, 8px);
+  align-self: center;
 }
 
 .save-date-date span {
@@ -721,6 +722,8 @@ body {
 
 .save-date-note {
   font-size: clamp(0.88rem, 1.9vw, 1.04rem);
+  text-align: center;
+  align-self: center;
 }
 
 .save-date-actions {


### PR DESCRIPTION
## Summary
- ensure the date and location line stays centered within the save-the-date details view
- center the "Formal invite to follow" note to match the date section

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfbce134b0832eadd4beda94e04e08