### PR TITLE
Refine action layout and improve mobile calendar menu

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -26,6 +26,18 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html, body {
   height: 100%;
   min-height: 100%;
@@ -559,10 +571,11 @@ body {
   transform: translateX(4px);
 }
 
-@media (max-width: 680px) {
+@media (max-width: 820px) {
   .save-date-calendar {
     position: static;
     width: 100%;
+    justify-content: center;
   }
 
   .save-date-calendar-details {
@@ -578,8 +591,8 @@ body {
 
   .save-date-calendar-menu {
     position: static;
-    width: 100%;
-    max-width: min(100%, 320px);
+    width: min(100%, 360px);
+    max-width: min(100%, 360px);
     margin-top: 14px;
     margin-inline: auto;
     opacity: 1;
@@ -594,6 +607,7 @@ body {
 
   .save-date-header {
     flex-direction: column;
+    align-items: center;
     gap: clamp(16px, 4vw, 20px);
   }
 }
@@ -726,9 +740,25 @@ body {
 .save-date-actions {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: clamp(10px, 2.4vw, 16px);
   width: min(100%, 640px);
+  margin-inline: auto;
+}
+
+.save-date-action-icons {
+  display: flex;
+  justify-content: center;
+  gap: clamp(12px, 3.6vw, 18px);
+  align-items: center;
+  width: min(100%, 320px);
+  margin-inline: auto;
+  align-self: center;
+}
+
+.save-date-action--full {
+  width: min(100%, 440px);
+  min-width: 0;
   margin-inline: auto;
 }
 
@@ -751,6 +781,45 @@ body {
     border-color 0.25s ease;
   text-decoration: none;
   min-width: clamp(200px, 58%, 260px);
+}
+
+.save-date-action--icon-only {
+  position: relative;
+  min-width: 0;
+  width: clamp(54px, 14vw, 66px);
+  height: clamp(54px, 14vw, 66px);
+  padding: clamp(10px, 2.6vw, 12px);
+  border-radius: 50%;
+  gap: 0;
+  background: rgba(12, 63, 43, 0.12);
+  border-color: rgba(12, 44, 29, 0.2);
+}
+
+.save-date-action--icon-only::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translate3d(-50%, -8px, 0);
+  background: rgba(12, 44, 29, 0.94);
+  color: var(--cream);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: clamp(0.6rem, 1.4vw, 0.75rem);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
+  transition: opacity var(--transition), transform var(--transition);
+  z-index: 5;
+}
+
+.save-date-action--icon-only:hover::after,
+.save-date-action--icon-only:focus-visible::after {
+  opacity: 1;
+  transform: translate3d(-50%, 0, 0);
 }
 
 .save-date-action:hover,
@@ -779,9 +848,22 @@ body {
   box-shadow: 0 10px 20px rgba(3, 40, 28, 0.28);
 }
 
+.save-date-action--icon-only .save-date-action__icon {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: var(--emerald-mid);
+  box-shadow: none;
+}
+
 .save-date-action__icon-graphic {
   width: clamp(16px, 3.2vw, 18px);
   height: clamp(16px, 3.2vw, 18px);
+}
+
+.save-date-action--icon-only .save-date-action__icon-graphic {
+  width: clamp(22px, 5vw, 26px);
+  height: clamp(22px, 5vw, 26px);
 }
 
 .save-date-action__label {
@@ -826,14 +908,17 @@ body {
 
 @media (min-width: 560px) {
   .save-date-actions {
-    flex-direction: row;
-    justify-content: center;
-    flex-wrap: wrap;
+    align-items: center;
     gap: clamp(12px, 2.2vw, 18px);
   }
 
-  .save-date-action {
-    min-width: clamp(180px, 32%, 240px);
+  .save-date-action--full {
+    width: min(100%, 500px);
+  }
+
+  .save-date-action-icons {
+    width: min(100%, 360px);
+    gap: clamp(14px, 2.6vw, 20px);
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -460,6 +460,9 @@
    * @param {string} [config.viewBox='0 0 24 24'] - SVG viewBox
    * @param {string} [config.element='button'] - HTML element type ('button' or 'a')
    * @param {string} [config.href=''] - Link URL for anchor elements
+   * @param {boolean} [config.isIconOnly=false] - Whether to render as icon-only button
+   * @param {string} [config.tooltipText=''] - Optional tooltip text
+   * @param {string} [config.ariaLabel=''] - Custom accessible label
    * @returns {HTMLElement} The configured button element
    */
   const createSaveTheDateActionButton = ({
@@ -469,10 +472,13 @@
     viewBox = '0 0 24 24',
     element = 'button',
     href = '',
+    isIconOnly = false,
+    tooltipText = '',
+    ariaLabel = '',
   }) => {
     const tagName = element === 'a' ? 'a' : 'button';
     const button = document.createElement(tagName);
-    
+
     // Configure element based on type
     if (tagName === 'button') {
       button.type = 'button';
@@ -483,8 +489,30 @@
     } else {
       button.href = '#';
     }
-    
-    button.className = `save-date-action${additionalClassName ? ` ${additionalClassName}` : ''}`;
+
+    if (ariaLabel) {
+      button.setAttribute('aria-label', ariaLabel);
+    }
+
+    const buttonClassNames = ['save-date-action'];
+    if (additionalClassName) {
+      buttonClassNames.push(additionalClassName);
+    }
+    if (isIconOnly) {
+      buttonClassNames.push('save-date-action--icon-only');
+    }
+
+    button.className = buttonClassNames.join(' ');
+
+    if (!ariaLabel && isIconOnly) {
+      button.setAttribute('aria-label', label);
+    }
+
+    const tooltipLabel = tooltipText || (isIconOnly ? label : '');
+    if (tooltipLabel) {
+      button.dataset.tooltip = tooltipLabel;
+      button.setAttribute('title', tooltipLabel);
+    }
 
     // Create icon container
     const icon = document.createElement('span');
@@ -506,6 +534,9 @@
     // Create label
     const labelEl = document.createElement('span');
     labelEl.className = 'save-date-action__label';
+    if (isIconOnly) {
+      labelEl.classList.add('visually-hidden');
+    }
     labelEl.textContent = label;
 
     button.append(icon, labelEl);
@@ -570,25 +601,33 @@
       iconPath: 'M12 4a4 4 0 0 1 4 4v1h1a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H8a3 3 0 0 1-3-3v-6a3 3 0 0 1 3-3h1V8a4 4 0 0 1 4-4zm0 2a2 2 0 0 0-2 2v1h4V8a2 2 0 0 0-2-2zm5 5H8a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1z',
       element: 'a',
       href: 'https://becomingcummings.love',
+      isIconOnly: true,
+      tooltipText: 'Wedding website',
+      ariaLabel: 'Visit our wedding website (opens in a new tab)',
     });
-    websiteLink.setAttribute('aria-label', 'Visit our wedding website (opens in a new tab)');
 
     // Replay video button
     const replayButton = createSaveTheDateActionButton({
       label: 'Replay celebration video',
       iconPath: 'M12 5.5V2L5.5 8.5 12 15V10.6c3.15 0 5.9 2.55 5.9 5.9s-2.55 5.9-5.9 5.9-5.9-2.55-5.9-5.9h-2c0 4.36 3.54 7.9 7.9 7.9s7.9-3.54 7.9-7.9S16.36 8.6 12 8.6z',
+      isIconOnly: true,
+      tooltipText: 'Replay video',
+      ariaLabel: 'Replay celebration video',
     });
-    replayButton.setAttribute('aria-label', 'Replay celebration video');
 
     // Venue sneak peek button
     const sneakPeekButton = createSaveTheDateActionButton({
       label: 'Venue sneak peek',
       iconPath: 'M8 5.5v13l11-6.5-11-6.5z',
-      additionalClassName: 'save-date-action--secondary',
+      additionalClassName: 'save-date-action--secondary save-date-action--full',
     });
     sneakPeekButton.setAttribute('aria-label', 'Play the venue sneak peek video');
 
-    actions.append(websiteLink, replayButton, sneakPeekButton);
+    const iconActions = document.createElement('div');
+    iconActions.className = 'save-date-action-icons';
+    iconActions.append(replayButton, websiteLink);
+
+    actions.append(sneakPeekButton, iconActions);
     return { actions, websiteLink, replayButton, sneakPeekButton };
   };
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -504,9 +504,6 @@
 
     button.className = buttonClassNames.join(' ');
 
-    if (!ariaLabel && isIconOnly) {
-      button.setAttribute('aria-label', label);
-    }
 
     const tooltipLabel = tooltipText || (isIconOnly ? label : '');
     if (tooltipLabel) {


### PR DESCRIPTION
## Summary
- add icon-only action support and reorder the save-the-date actions so the venue sneak peek is the primary control
- refresh styling for the compact icon row with hover tooltips to create more breathing room
- broaden the mobile calendar layout overrides so the add-to-calendar links stay on-screen

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfbcc5e88c832ea9aa21db60752f2d