### PR TITLE
Remove countdown overlay after activation

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1351,11 +1351,9 @@
         startOverlay.classList.add('hidden');
         startOverlay.setAttribute('aria-hidden', 'true');
         startOverlay.setAttribute('tabindex', '-1');
-        window.setTimeout(() => {
-          if (startOverlay.parentElement) {
-            startOverlay.remove();
-          }
-        }, START_OVERLAY_CLEAR_DELAY_MS);
+        if (startOverlay.parentElement) {
+          startOverlay.remove();
+        }
       }, START_OVERLAY_CLEAR_DELAY_MS);
     }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1351,6 +1351,11 @@
         startOverlay.classList.add('hidden');
         startOverlay.setAttribute('aria-hidden', 'true');
         startOverlay.setAttribute('tabindex', '-1');
+        window.setTimeout(() => {
+          if (startOverlay.parentElement) {
+            startOverlay.remove();
+          }
+        }, START_OVERLAY_CLEAR_DELAY_MS);
       }, START_OVERLAY_CLEAR_DELAY_MS);
     }
 


### PR DESCRIPTION
## Summary
- remove the countdown overlay node from the DOM after the start animation completes so the disabled button can no longer show up over the save-the-date card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03f4637b4832ebd2ac3a138fab0e5