### PR TITLE
Enlarge favicon icon in circular action buttons

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -865,8 +865,8 @@ body {
 }
 
 .save-date-action--icon-only .save-date-action__icon-graphic {
-  width: clamp(22px, 5vw, 26px);
-  height: clamp(22px, 5vw, 26px);
+  width: clamp(34px, 7.8vw, 44px);
+  height: clamp(34px, 7.8vw, 44px);
 }
 
 .save-date-action__label {


### PR DESCRIPTION
## Summary
- enlarge the icon graphics displayed in circular action buttons so the favicon nearly fills the button

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0483c1aec832e8c60185ef0404990