### PR TITLE
Hide skip link off screen until focused

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -76,7 +76,7 @@ a:focus-visible,
 
 .skip-link {
   position: absolute;
-  top: -40px;
+  top: 6px;
   left: 6px;
   background: var(--accent);
   color: var(--text-dark);
@@ -85,11 +85,13 @@ a:focus-visible,
   border-radius: 4px;
   font-weight: 600;
   z-index: 1000;
-  transition: top 0.3s ease;
+  transform: translateY(-180%);
+  transition: transform 0.3s ease;
 }
 
-.skip-link:focus {
-  top: 6px;
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
 }
 
 .noscript-note {


### PR DESCRIPTION
## Summary
- keep the skip link off screen using a translate transform until it receives focus
- ensure the skip link reveals for both focus and focus-visible states without showing a stray accent line

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d21946ace0832e852ff5c1daf5daf6