### PR TITLE
Add hotel reservations button to save-the-date actions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -815,7 +815,7 @@
     iconActions.append(replayButton, websiteLink);
 
     actions.append(sneakPeekButton, hotelButton, iconActions);
-    return { actions, websiteLink, replayButton, sneakPeekButton };
+    return { actions, websiteLink, replayButton, sneakPeekButton, hotelButton };
   };
 
   /**


### PR DESCRIPTION
## Summary
- add a dedicated hotel reservations button beneath the venue sneak peek action
- clarify the call-to-action label to read “Hotel reservations”

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5d7e89124832eb79c86f91e8bebae