### PR TITLE
Add dramatic finale to mobile photo sequence

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -383,6 +383,28 @@ main > .page-border {
   display: block;
 }
 
+.mobile-frame--photo-final {
+  position: relative;
+}
+
+.mobile-frame__image--final {
+  animation: mobileFinalPhotoZoom 4.56s cubic-bezier(0.18, 0, 0.12, 1) forwards;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+@keyframes mobileFinalPhotoZoom {
+  0% {
+    transform: scale(0.7);
+  }
+  42% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.45);
+  }
+}
+
 
 
 .mobile-frame--video {
@@ -418,6 +440,14 @@ main > .page-border {
   object-fit: cover;
   object-position: center center; /* Center for videos */
   display: block;
+}
+
+.mobile-frame--video.mobile-frame--video-slow-reveal {
+  transition: opacity 1.2s ease, transform 1.2s ease;
+}
+
+.mobile-frame--video.mobile-frame--video-slow-reveal.is-visible {
+  transition: opacity 1.2s ease, transform 1.2s ease;
 }
 
 .mobile-frame--card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -128,6 +128,8 @@
     { start: 2000, step: 140, min: 1200 },
     { start: 1100, step: 160, min: 420 },
   ];
+  const MOBILE_FINAL_PHOTO_ANIMATION_DURATION_MS = 4200;
+  const MOBILE_FINAL_PHOTO_ADDITIONAL_DELAY_MS = 360;
 
   // Content settings
   const COUNTDOWN_START_FALLBACK = 10;
@@ -1522,13 +1524,16 @@
     }
   };
 
-  const showMobileVideo = () => {
+  const showMobileVideo = ({ isFromFinalPhoto = false } = {}) => {
     if (!mobileStage) {
       return;
     }
 
     const { wrapper, celebrationVideo } = buildCelebrationVideo();
     const frame = createMobileFrame('mobile-frame--video');
+    if (!prefersReducedMotion && isFromFinalPhoto) {
+      frame.classList.add('mobile-frame--video-slow-reveal');
+    }
     frame.appendChild(wrapper);
 
     swapMobileFrame(frame);
@@ -1597,6 +1602,14 @@
     const image = document.createElement('img');
     image.src = photoDetails.src;
     image.alt = photoDetails.alt || '';
+    const isFinalPhoto =
+      !prefersReducedMotion &&
+      cycleIndex === mobilePhotoLoopCount - 1 &&
+      index === mobilePhotoDetails.length - 1;
+    if (isFinalPhoto) {
+      frame.classList.add('mobile-frame--photo-final');
+      image.classList.add('mobile-frame__image--final');
+    }
     frame.appendChild(image);
 
     swapMobileFrame(frame);
@@ -1607,6 +1620,17 @@
       ? transitionDelay + MOBILE_PHOTO_TRANSITION_BUFFER_MS
       : 0;
     const scheduleDelay = Math.max(displayDuration, minimumDelay);
+
+    if (isFinalPhoto) {
+      const finalDelay = Math.max(
+        MOBILE_FINAL_PHOTO_ANIMATION_DURATION_MS + MOBILE_FINAL_PHOTO_ADDITIONAL_DELAY_MS,
+        scheduleDelay
+      );
+      window.setTimeout(() => {
+        showMobileVideo({ isFromFinalPhoto: true });
+      }, finalDelay);
+      return;
+    }
 
     window.setTimeout(() => {
       showMobilePhotoAtIndex(index + 1, cycleIndex);


### PR DESCRIPTION
## Summary
- add timing controls for the final mobile photo so it performs a long zoom before handing off to video
- animate the final mobile photo and slow the ensuing video reveal for a more dramatic mobile-only transition

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5e5e83cc0832ea85a53ce8a167c8b