### PR TITLE
Add sound-on hint to countdown start overlay

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -559,6 +559,24 @@ main > .page-border {
   outline-offset: 4px;
 }
 
+.countdown-overlay-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-family: 'Spectral', serif;
+  font-size: clamp(0.75rem, 2.2vw, 1rem);
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  text-align: center;
+  margin: 0;
+}
+
+.countdown-overlay-hint span {
+  font-size: 1.2em;
+  line-height: 1;
+}
+
 .countdown-overlay-content.is-clearing {
   opacity: 0;
   transform: scale(0.97);

--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -572,7 +572,7 @@ main > .page-border {
   margin: 0;
 }
 
-.countdown-overlay-hint span {
+.countdown-overlay-hint [aria-hidden] {
   font-size: 1.2em;
   line-height: 1;
 }

--- a/index.html
+++ b/index.html
@@ -25,11 +25,15 @@
     tabindex="0"
     aria-label="Start the countdown experience - Press Enter or Space to begin"
     aria-controls="mainContent"
-    aria-describedby="startInstructions"
+    aria-describedby="startInstructions soundInstructions"
   >
     <div class="countdown-overlay-content">
       <span class="countdown-overlay-line countdown-overlay-line--top">get ready</span>
       <button class="countdown-overlay-button" id="startCountdownButton" type="button">click here</button>
+      <p class="countdown-overlay-hint" id="soundInstructions">
+        <span aria-hidden="true">🔊</span>
+        Turn your sound on for the full experience.
+      </p>
       <span class="countdown-overlay-line countdown-overlay-line--bottom">to party</span>
       <span id="startInstructions" class="visually-hidden">This will start an interactive countdown and photo experience for Lorraine and Christopher's wedding celebration</span>
     </div>


### PR DESCRIPTION
## Summary
- add a sound-on reminder below the start button and describe it via aria-describedby
- style the reminder for readability alongside the existing start overlay layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89a5b3740832e89593c2030a8f6ed