### PR TITLE
Add explicit sound permission flow for celebration video

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -598,6 +598,7 @@ main > .page-border {
   padding: clamp(16px, 3.6vw, 30px);
   justify-content: center;
   align-items: stretch;
+  position: relative;
 }
 
 .countdown-wrapper.has-details {
@@ -846,6 +847,79 @@ main > .page-border {
   object-fit: cover;
   object-position: center center; /* Center for videos */
   display: block;
+}
+
+.sound-permission {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(20px, 4.6vw, 32px);
+  transform: translate(-50%, 12px);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(8px, 2.6vw, 14px);
+  padding: clamp(10px, 2.4vw, 16px) clamp(16px, 4vw, 22px);
+  border-radius: 999px;
+  background: rgba(3, 40, 28, 0.9);
+  color: #f5f1eb;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+  font-size: clamp(0.78rem, 2.1vw, 0.95rem);
+  letter-spacing: 0.05em;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.24s ease, transform 0.24s ease;
+  z-index: 2;
+}
+
+.sound-permission__message {
+  margin: 0;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.sound-permission__button {
+  border: none;
+  border-radius: 999px;
+  background: #ffe3a2;
+  color: var(--text-dark);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 18px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.sound-permission__button:hover,
+.sound-permission__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+}
+
+.sound-permission--visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 640px) {
+  .sound-permission {
+    position: static;
+    transform: none;
+    width: 100%;
+    justify-content: center;
+    border-radius: clamp(18px, 3vw, 24px);
+    margin-top: clamp(12px, 3vw, 18px);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .sound-permission:not(.sound-permission--visible) {
+    display: none;
+  }
 }
 
 .video-hashtag {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -770,8 +770,8 @@
     }
 
     const controllingVideo = activeCelebrationVideoElement;
-    if (controllingVideo && !controllingVideo.muted) {
-      audio.muted = false;
+    if (controllingVideo) {
+      audio.muted = !controllingVideo.muted;
     }
 
     if (!audio.paused && !audio.ended) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -537,7 +537,6 @@
     if (resolvedWrapper) {
       currentCelebrationVideoWrapper = resolvedWrapper;
       ensureCelebrationAudioPermissionUi(resolvedWrapper);
-      hideCelebrationAudioPermissionUi();
     }
 
     let hasUserAdjustedVolume = false;


### PR DESCRIPTION
## Summary
- add a dedicated sound-permission prompt so the celebration video can request user interaction when autoplayed audio is blocked
- update celebration media synchronization to track the active video, retry audio playback on trusted gestures, and clear the prompt when sound starts
- style the new sound enable control for desktop and mobile layouts without disrupting existing content

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d8b5f6aa3c832e9d213ccb160e3007