### PR TITLE
Update sneak peek video to use embedded audio

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2047,9 +2047,13 @@
 
       safelyPlayVideo(video, {
         onError: (error) => {
-          if (error) {
-            console.info('Sneak peek video playback could not start automatically.', error);
-          }
+          // Always log the error, regardless of its truthiness, and provide type context
+          console.info(
+            'Sneak peek video playback could not start automatically.',
+            typeof error === 'undefined'
+              ? '[no error provided]'
+              : error
+          );
         },
       });
     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -133,9 +133,8 @@
 
   // Content settings
   const COUNTDOWN_START_FALLBACK = 10;
-  const VENUE_SNEAK_PEEK_VIDEO_SOURCE = 'assets/ChaletView480.mp4';
+  const VENUE_SNEAK_PEEK_VIDEO_SOURCE = 'assets/ChaletView.mp4';
   const CELEBRATION_AUDIO_SOURCE = 'assets/ReelAudio-33714.mp3';
-  const SNEAK_PEEK_AUDIO_SOURCE = 'assets/ReelAudio-71698.mp3';
   const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
   const SOUND_PERMISSION_VISIBLE_CLASS = 'sound-permission--visible';
   const SOUND_PERMISSION_ROLE = 'celebration-sound-permission';
@@ -154,8 +153,6 @@
   let sharedCelebrationAudioElement = null;
   let cleanupCelebrationMediaSync = null;
   let hasPrimedCelebrationAudioPlayback = false;
-  let sharedSneakPeekAudioElement = null;
-  let hasPrimedSneakPeekAudioPlayback = false;
   let activeCelebrationVideoElement = null;
   let celebrationAudioPermissionContainer = null;
   let celebrationAudioPermissionButton = null;
@@ -367,67 +364,6 @@
 
     isCelebrationAudioPlaybackBlocked = false;
     hideCelebrationAudioPermissionUi();
-  };
-
-  /**
-   * Creates the sneak peek audio element
-   * @returns {HTMLAudioElement} The configured audio element
-   */
-  const createSneakPeekAudioElement = () => {
-    const audio = document.createElement('audio');
-    audio.src = SNEAK_PEEK_AUDIO_SOURCE;
-    audio.preload = 'auto';
-    audio.autoplay = false;
-    audio.loop = true;
-    audio.controls = false;
-    audio.muted = false;
-    audio.setAttribute('playsinline', '');
-    audio.setAttribute('aria-hidden', 'true');
-    audio.dataset.role = 'sneak-peek-audio';
-    registerSharedAudioElement(audio);
-    return audio;
-  };
-
-  /**
-   * Gets or creates the shared sneak peek audio element
-   * @returns {HTMLAudioElement|null} The audio element
-   */
-  const getSneakPeekAudioElement = () => {
-    if (!sharedSneakPeekAudioElement) {
-      sharedSneakPeekAudioElement = createSneakPeekAudioElement();
-    }
-    return sharedSneakPeekAudioElement;
-  };
-
-  /**
-   * Pauses the sneak peek audio without resetting the playback position
-   */
-  const pauseSneakPeekAudio = () => {
-    if (!sharedSneakPeekAudioElement) {
-      return;
-    }
-
-    try {
-      sharedSneakPeekAudioElement.pause();
-    } catch (error) {
-      // Ignore pause errors while controlling sneak peek audio
-    }
-  };
-
-  /**
-   * Stops and rewinds the shared sneak peek audio
-   */
-  const stopSneakPeekAudio = () => {
-    if (!sharedSneakPeekAudioElement) {
-      return;
-    }
-
-    try {
-      sharedSneakPeekAudioElement.pause();
-      sharedSneakPeekAudioElement.currentTime = 0;
-    } catch (error) {
-      // Ignore errors while attempting to reset audio state
-    }
   };
 
   /**
@@ -666,92 +602,6 @@
       });
       audio.pause();
     };
-  };
-
-  /**
-   * Synchronizes sneak peek audio playback with the associated video element
-   * @param {HTMLVideoElement} video - The video element to mirror
-   * @param {HTMLAudioElement} audio - The audio element that provides the soundtrack
-   */
-  const setupSneakPeekMediaSync = ({ video, audio }) => {
-    if (!video || !audio) {
-      return;
-    }
-
-    const syncTime = () => {
-      try {
-        const videoTime = Number(video.currentTime);
-        if (!Number.isFinite(videoTime)) {
-          return;
-        }
-
-        const audioTime = Number(audio.currentTime);
-        if (!Number.isFinite(audioTime) || Math.abs(audioTime - videoTime) > 0.3) {
-          audio.currentTime = videoTime;
-        }
-      } catch (error) {
-        // Ignore sync errors; browser timing will settle naturally
-      }
-    };
-
-    const applyVolumeState = () => {
-      audio.muted = video.muted;
-      const resolvedVolume = Number.isFinite(video.volume) ? video.volume : 1;
-      audio.volume = resolvedVolume;
-    };
-
-    const applyPlaybackRate = () => {
-      try {
-        audio.playbackRate = video.playbackRate || 1;
-      } catch (error) {
-        // Ignore playback-rate sync errors
-      }
-    };
-
-    const unmuteMedia = () => {
-      video.muted = false;
-      video.defaultMuted = false;
-      video.removeAttribute('muted');
-      audio.muted = false;
-      audio.defaultMuted = false;
-      audio.removeAttribute('muted');
-    };
-
-    applyVolumeState();
-
-    let hasUnmutedOnPlay = false;
-
-    const syncAndResumeAudio = () => {
-      applyVolumeState();
-      applyPlaybackRate();
-      syncTime();
-      ensureSneakPeekAudioPlayback();
-    };
-
-    eventListenerManager.add(video, 'play', () => {
-      if (!hasUnmutedOnPlay) {
-        unmuteMedia();
-        hasUnmutedOnPlay = true;
-      }
-      syncAndResumeAudio();
-    });
-
-/* Removed redundant 'playing' event handler; audio sync is now handled by ensureAudioPlaybackWhenVideoActive in the 'play' handler. */
-
-    eventListenerManager.add(video, 'pause', () => {
-      pauseSneakPeekAudio();
-    });
-
-    eventListenerManager.add(video, 'ended', () => {
-      stopSneakPeekAudio();
-    });
-
-    eventListenerManager.add(video, 'seeking', syncTime);
-    eventListenerManager.add(video, 'seeked', syncTime);
-    // Removed redundant timeupdate handler to avoid unnecessary syncTime() calls.
-
-    eventListenerManager.add(video, 'volumechange', applyVolumeState);
-    eventListenerManager.add(video, 'ratechange', applyPlaybackRate);
   };
 
   /**
@@ -1026,92 +876,6 @@
       }
     } catch (error) {
       handlePrimerFailure(error);
-    }
-  };
-
-  /**
-   * Primes the sneak peek audio element to satisfy autoplay policies
-   */
-  const primeSneakPeekAudioPlayback = () => {
-    if (hasPrimedSneakPeekAudioPlayback) {
-      return;
-    }
-
-    const audio = getSneakPeekAudioElement();
-    if (!audio) {
-      return;
-    }
-
-    const originalMutedState = audio.muted;
-
-    const finalizePrimer = (wasSuccessful) => {
-      try {
-        audio.pause();
-      } catch (error) {
-        // Ignore pause errors during primer cleanup
-      }
-
-      try {
-        audio.currentTime = 0;
-      } catch (error) {
-        // Ignore rewind errors during primer cleanup
-      }
-
-      audio.muted = originalMutedState;
-
-      if (wasSuccessful) {
-        hasPrimedSneakPeekAudioPlayback = true;
-      }
-    };
-
-    try {
-      audio.muted = true;
-      const playPromise = audio.play();
-
-      if (playPromise && typeof playPromise.then === 'function') {
-        playPromise
-          .then(() => {
-            finalizePrimer(true);
-          })
-          .catch(() => {
-            finalizePrimer(false);
-          });
-      } else {
-        setTimeout(() => {
-          if (!audio.paused) {
-            finalizePrimer(true);
-          } else {
-            finalizePrimer(false);
-          }
-        }, 100);
-      }
-    } catch (error) {
-      finalizePrimer(false);
-    }
-  };
-
-  /**
-   * Ensures the sneak peek audio track is playing
-   */
-  const ensureSneakPeekAudioPlayback = () => {
-    const audio = getSneakPeekAudioElement();
-    if (!audio) {
-      return;
-    }
-
-    if (audio.muted) {
-      audio.muted = false;
-    }
-
-    if (!audio.paused) {
-      return;
-    }
-
-    const playPromise = audio.play();
-    if (playPromise && typeof playPromise.then === 'function') {
-      playPromise.catch(() => {
-        // Allow playback failures to fail silently; user can retry by pressing play on the video
-      });
     }
   };
 
@@ -2086,7 +1850,6 @@
 
     resetCelebrationMediaSync();
     stopCelebrationAudio();
-    stopSneakPeekAudio();
 
     const elements = buildSaveTheDateDetails();
     targetContainer.innerHTML = '';
@@ -2165,10 +1928,11 @@
     video.className = 'sneak-peek-embed';
     video.src = VENUE_SNEAK_PEEK_VIDEO_SOURCE;
     video.controls = true;
-    video.preload = 'metadata';
-    video.muted = true;
-    video.defaultMuted = true;
-    video.setAttribute('muted', '');
+    video.preload = 'auto';
+    video.autoplay = true;
+    video.muted = false;
+    video.defaultMuted = false;
+    video.removeAttribute('muted');
     video.setAttribute('playsinline', '');
     video.setAttribute('aria-label', 'Sneak peek of the celebration venue');
 
@@ -2208,7 +1972,6 @@
   } = {}) => {
     if (!targetContainer) return;
 
-    stopSneakPeekAudio();
     const { wrapper, celebrationVideo } = buildCelebrationVideo();
     const celebrationAudio = getCelebrationAudioElement();
     targetContainer.innerHTML = '';
@@ -2264,19 +2027,8 @@
 
     resetCelebrationMediaSync();
     stopCelebrationAudio();
-    stopSneakPeekAudio();
 
     const { wrapper, video, backButton } = buildSneakPeekVideo();
-    const sneakPeekAudio = getSneakPeekAudioElement();
-
-    if (sneakPeekAudio) {
-      try {
-        sneakPeekAudio.currentTime = 0;
-        sneakPeekAudio.muted = true;
-      } catch (error) {
-        // Ignore errors while rewinding sneak peek audio
-      }
-    }
 
     targetContainer.innerHTML = '';
     targetContainer.appendChild(wrapper);
@@ -2289,9 +2041,17 @@
 
     if (video) {
       video.currentTime = 0;
-      if (sneakPeekAudio) {
-        setupSneakPeekMediaSync({ video, audio: sneakPeekAudio });
-      }
+      video.muted = false;
+      video.defaultMuted = false;
+      video.removeAttribute('muted');
+
+      safelyPlayVideo(video, {
+        onError: (error) => {
+          if (error) {
+            console.info('Sneak peek video playback could not start automatically.', error);
+          }
+        },
+      });
     }
   };
 
@@ -2338,7 +2098,6 @@
 
     resetCelebrationMediaSync();
     stopCelebrationAudio();
-    stopSneakPeekAudio();
 
     const elements = buildSaveTheDateDetails();
     const frame = createMobileFrame('mobile-frame--card');
@@ -2371,7 +2130,6 @@
       return;
     }
 
-    stopSneakPeekAudio();
     const { wrapper, celebrationVideo } = buildCelebrationVideo();
     const celebrationAudio = getCelebrationAudioElement();
     const frame = createMobileFrame('mobile-frame--video');
@@ -2416,18 +2174,8 @@
 
     resetCelebrationMediaSync();
     stopCelebrationAudio();
-    stopSneakPeekAudio();
 
     const { wrapper, video, backButton } = buildSneakPeekVideo();
-    const sneakPeekAudio = getSneakPeekAudioElement();
-
-    if (sneakPeekAudio) {
-      try {
-        sneakPeekAudio.currentTime = 0;
-      } catch (error) {
-        // Ignore errors while rewinding sneak peek audio
-      }
-    }
 
     const frame = createMobileFrame('mobile-frame--video');
     frame.appendChild(wrapper);
@@ -2436,9 +2184,17 @@
 
     if (video) {
       video.currentTime = 0;
-      if (sneakPeekAudio) {
-        setupSneakPeekMediaSync({ video, audio: sneakPeekAudio });
-      }
+      video.muted = false;
+      video.defaultMuted = false;
+      video.removeAttribute('muted');
+
+      safelyPlayVideo(video, {
+        onError: (error) => {
+          if (error) {
+            console.info('Sneak peek video playback could not start automatically.', error);
+          }
+        },
+      });
     }
 
     if (backButton) {
@@ -2620,7 +2376,6 @@
     const context = getAudioContext();
     resumeContextIfSuspended(context);
     primeCelebrationAudioPlayback();
-    primeSneakPeekAudioPlayback();
 
     if (isMobileExperienceActive) {
       primeMobileCelebrationVideoPlayback();


### PR DESCRIPTION
## Summary
- swap the venue sneak peek source to the new ChaletView.mp4 asset that includes audio
- remove the dedicated sneak peek audio element and synchronization logic
- autoplay the venue sneak peek video with sound after the button is pressed on both desktop and mobile views

## Testing
- Manual - Loaded the page locally and triggered the venue sneak peek playback

------
https://chatgpt.com/codex/tasks/task_e_68d8c04a0518832eb5a4c005a7cf577d