### PR TITLE
Ensure celebration videos play with sound

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -160,12 +160,10 @@
     video.defaultMuted = false;
     video.removeAttribute('muted');
 
-    if (typeof video.volume === 'number') {
-      try {
-        video.volume = 1;
-      } catch (error) {
-        // Ignore browsers that prevent direct volume manipulation
-      }
+    try {
+      video.volume = 1;
+    } catch (error) {
+      // Ignore browsers that prevent direct volume manipulation
     }
   };
 


### PR DESCRIPTION
## Summary
- enable sound on celebration and sneak peek videos as soon as playback begins
- add helpers that automatically unmute videos once they start playing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9a1ad1118832e8185858c4c03835d