### PR TITLE
Fix video embeds for celebration and sneak peek

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -434,12 +434,22 @@ main > .page-border {
   height: 100%;
 }
 
-.mobile-frame--video .countdown-video {
+.mobile-frame--video .countdown-video:not(.countdown-video--embedded) {
   width: 100vw;
   height: 100dvh;
   object-fit: cover;
   object-position: center center; /* Center for videos */
   display: block;
+}
+
+.mobile-frame--video .countdown-video.countdown-video--embedded {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.mobile-frame--video .countdown-video-frame.countdown-video-frame--embedded {
+  height: auto;
 }
 
 .mobile-frame--video.mobile-frame--video-slow-reveal {
@@ -841,12 +851,26 @@ main > .page-border {
   min-height: 0;
 }
 
+.countdown-video-frame.countdown-video-frame--embedded {
+  position: relative;
+  display: block;
+  padding-top: 56.25%;
+}
+
 .countdown-video {
   width: 100%;
   height: 100%;
   object-fit: cover;
   object-position: center center; /* Center for videos */
   display: block;
+}
+
+.countdown-video-frame.countdown-video-frame--embedded > .countdown-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .video-hashtag {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -133,8 +133,8 @@
 
   // Content settings
   const COUNTDOWN_START_FALLBACK = 10;
-  const VENUE_SNEAK_PEEK_VIDEO_SOURCE = 'assets/CelebrationVideo.mp4';
-  const CELEBRATION_VIDEO_SOURCE = VENUE_SNEAK_PEEK_VIDEO_SOURCE;
+  const CELEBRATION_VIDEO_SOURCE = 'assets/CelebrationVideo.mp4';
+  const VENUE_SNEAK_PEEK_VIDEO_SOURCE = 'assets/ChaletView.mp4';
   const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 
   // =====================================================================
@@ -194,7 +194,7 @@
    */
   const createCelebrationVideoElement = () => {
     const video = document.createElement('video');
-    video.className = 'countdown-video';
+    video.className = 'countdown-video countdown-video--embedded';
     video.src = CELEBRATION_VIDEO_SOURCE;
     video.preload = 'auto';
     video.autoplay = true;
@@ -1432,7 +1432,7 @@
     videoHashtag.textContent = '#BECOMINGCUMMINGS';
 
     const videoFrame = document.createElement('div');
-    videoFrame.className = 'countdown-video-frame';
+    videoFrame.className = 'countdown-video-frame countdown-video-frame--embedded';
 
     const celebrationVideo = getCelebrationVideoElement();
     celebrationVideo.pause();
@@ -1463,10 +1463,10 @@
     videoHashtag.textContent = 'Venue sneak peek';
 
     const videoFrame = document.createElement('div');
-    videoFrame.className = 'countdown-video-frame sneak-peek-frame';
+    videoFrame.className = 'countdown-video-frame countdown-video-frame--embedded sneak-peek-frame';
 
     const video = document.createElement('video');
-    video.className = 'sneak-peek-embed';
+    video.className = 'countdown-video countdown-video--embedded sneak-peek-embed';
     video.src = VENUE_SNEAK_PEEK_VIDEO_SOURCE;
     video.controls = true;
     video.preload = 'auto';


### PR DESCRIPTION
## Summary
- use separate video sources for the celebration and sneak peek experiences
- render both videos in an embedded frame so controls remain visible on all screen sizes
- adjust mobile styling so embedded videos maintain their aspect ratio instead of being cropped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db14d1ba74832eacbb95a5a6058bb7