### PR TITLE
Add celebration video details

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -873,6 +873,21 @@ main > .page-border {
   object-fit: contain;
 }
 
+.celebration-video-details {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(6px, 1.6vw, 14px);
+  margin: clamp(12px, 2.4vw, 20px) 0 0;
+}
+
+.celebration-video-detail {
+  color: var(--emerald-mid);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .video-hashtag {
   font-size: clamp(0.8rem, 1.8vw, 1rem);
   letter-spacing: 0.32em;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1453,7 +1453,8 @@
 
     const celebrationVenue = document.createElement('p');
     celebrationVenue.className = 'countdown-note celebration-video-detail';
-    celebrationVenue.textContent = 'Chalet View Lodge';
+    // Make venue name configurable via data attribute, fallback to default
+    celebrationVenue.textContent = wrapper?.dataset?.venueName || 'Chalet View Lodge';
 
     const celebrationLocation = document.createElement('p');
     celebrationLocation.className = 'countdown-note celebration-video-detail';

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1444,8 +1444,28 @@
 
     videoFrame.appendChild(celebrationVideo);
 
+    const videoDetails = document.createElement('div');
+    videoDetails.className = 'celebration-video-details';
+
+    const celebrationDate = document.createElement('p');
+    celebrationDate.className = 'countdown-note celebration-video-detail';
+    celebrationDate.textContent = '9/12/2026';
+
+    const celebrationVenue = document.createElement('p');
+    celebrationVenue.className = 'countdown-note celebration-video-detail';
+    celebrationVenue.textContent = 'Chalet View Lodge';
+
+    const celebrationLocation = document.createElement('p');
+    celebrationLocation.className = 'countdown-note celebration-video-detail';
+    celebrationLocation.textContent = 'Portola CA';
+
+    videoDetails.appendChild(celebrationDate);
+    videoDetails.appendChild(celebrationVenue);
+    videoDetails.appendChild(celebrationLocation);
+
     wrapper.appendChild(videoHashtag);
     wrapper.appendChild(videoFrame);
+    wrapper.appendChild(videoDetails);
 
     return { wrapper, celebrationVideo };
   };


### PR DESCRIPTION
## Summary
- add event date and location details below the celebration video
- style the new detail text to match the existing design language

## Testing
- Manual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68db22458fc4832eaf325eaf44fa21c2