### PR TITLE
Ensure font preload element is initialized

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,13 @@
   <title>Save the Date</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&amp;family=Spectral:wght@400;600&amp;display=swap">
+  <link
+    id="font-preload"
+    rel="preload"
+    as="style"
+    href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&amp;family=Spectral:wght@400;600&amp;display=swap"
+    crossorigin
+  >
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;600&display=swap"></noscript>
   <link rel="preload" href="assets/css/bordered-gallery.css" as="style">
   <link rel="preload" href="assets/js/main.js" as="script">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     rel="preload"
     as="style"
     href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&amp;family=Spectral:wght@400;600&amp;display=swap"
-    crossorigin
+    crossorigin="anonymous"
   >
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;600&display=swap"></noscript>
   <link rel="preload" href="assets/css/bordered-gallery.css" as="style">


### PR DESCRIPTION
## Summary
- add the missing `font-preload` link element so the font loading script can promote it to a stylesheet at runtime

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e16c8cc8bc832ea4f6b2db7975cf19