### PR TITLE
Add skip intro control to countdown overlay

### DIFF
--- a/assets/css/bordered-gallery.css
+++ b/assets/css/bordered-gallery.css
@@ -569,6 +569,38 @@ main > .page-border {
   outline-offset: 4px;
 }
 
+.countdown-overlay-skip {
+  font-family: 'Spectral', serif;
+  font-size: clamp(0.65rem, 1.8vw, 0.85rem);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: clamp(6px, 1.4vw, 10px) clamp(18px, 4vw, 26px);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease,
+    border-color 0.25s ease, box-shadow 0.25s ease;
+  margin-top: auto;
+  align-self: center;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+}
+
+.countdown-overlay-skip:hover,
+.countdown-overlay-skip:focus-visible {
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--emerald-dark);
+  border-color: transparent;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
+}
+
+.countdown-overlay-skip:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
 .countdown-overlay-hint {
   display: inline-flex;
   align-items: center;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1967,19 +1967,8 @@
 
     hasStarted = true;
 
-    if (startOverlay) {
-      startOverlay.removeEventListener('click', startExperience);
-      startOverlay.removeEventListener('keydown', handleOverlayKeyDown);
-    }
-
-    if (startButton) {
-      startButton.removeEventListener('click', startExperience);
-    }
-
-    if (skipIntroButton) {
-      skipIntroButton.removeEventListener('click', skipExperience);
-    }
-
+    // Clean up all tracked event listeners using the manager
+    eventListenerManager.cleanup();
     gracefullyHideStartOverlay();
 
     if (isMobileExperienceActive) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -678,6 +678,38 @@
   if (!startButton) {
     console.warn('Main: startCountdownButton element not found - manual start may not work');
   }
+  const skipIntroButton = document.getElementById('skipIntroButton');
+  if (!skipIntroButton) {
+    console.warn('Main: skipIntroButton element not found - skip intro control unavailable');
+  }
+
+  const gracefullyHideStartOverlay = () => {
+    if (startOverlayContent) {
+      startOverlayContent.classList.add('is-clearing');
+    }
+
+    if (startButton) {
+      startButton.disabled = true;
+      startButton.setAttribute('tabindex', '-1');
+    }
+
+    if (skipIntroButton) {
+      skipIntroButton.disabled = true;
+      skipIntroButton.setAttribute('tabindex', '-1');
+    }
+
+    if (startOverlay) {
+      startOverlay.classList.add('is-counting');
+      window.setTimeout(() => {
+        startOverlay.classList.add('hidden');
+        startOverlay.setAttribute('aria-hidden', 'true');
+        startOverlay.setAttribute('tabindex', '-1');
+        if (startOverlay.parentElement) {
+          startOverlay.remove();
+        }
+      }, START_OVERLAY_CLEAR_DELAY_MS);
+    }
+  };
 
   /**
    * Reveals the next border cell in sequence during countdown
@@ -1886,29 +1918,20 @@
 
     hasStarted = true;
 
-    if (startOverlayContent) {
-      startOverlayContent.classList.add('is-clearing');
-    }
-
     if (startOverlay) {
       startOverlay.removeEventListener('click', startExperience);
       startOverlay.removeEventListener('keydown', handleOverlayKeyDown);
-      startOverlay.classList.add('is-counting');
-      window.setTimeout(() => {
-        startOverlay.classList.add('hidden');
-        startOverlay.setAttribute('aria-hidden', 'true');
-        startOverlay.setAttribute('tabindex', '-1');
-        if (startOverlay.parentElement) {
-          startOverlay.remove();
-        }
-      }, START_OVERLAY_CLEAR_DELAY_MS);
     }
 
     if (startButton) {
       startButton.removeEventListener('click', startExperience);
-      startButton.disabled = true;
-      startButton.setAttribute('tabindex', '-1');
     }
+
+    if (skipIntroButton) {
+      skipIntroButton.removeEventListener('click', skipExperience);
+    }
+
+    gracefullyHideStartOverlay();
 
     const context = getAudioContext();
     resumeContextIfSuspended(context);
@@ -1932,6 +1955,40 @@
     }
   };
 
+  const skipExperience = (event) => {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    if (hasStarted) {
+      return;
+    }
+
+    hasStarted = true;
+
+    if (startOverlay) {
+      startOverlay.removeEventListener('click', startExperience);
+      startOverlay.removeEventListener('keydown', handleOverlayKeyDown);
+    }
+
+    if (startButton) {
+      startButton.removeEventListener('click', startExperience);
+    }
+
+    if (skipIntroButton) {
+      skipIntroButton.removeEventListener('click', skipExperience);
+    }
+
+    gracefullyHideStartOverlay();
+
+    if (isMobileExperienceActive) {
+      showMobileSaveTheDate({ withCelebrateEffects: false });
+    } else {
+      showSaveTheDateDetails({ withCelebrateEffects: false });
+    }
+  };
+
   // Wire up interactions with proper event management --------------
   if (startButton) {
     eventListenerManager.add(startButton, 'click', startExperience);
@@ -1940,6 +1997,10 @@
   if (startOverlay) {
     eventListenerManager.add(startOverlay, 'click', startExperience);
     eventListenerManager.add(startOverlay, 'keydown', handleOverlayKeyDown);
+  }
+
+  if (skipIntroButton) {
+    eventListenerManager.add(skipIntroButton, 'click', skipExperience);
   }
 
   if (!startOverlay || !startButton) {

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         Turn your sound on for the full experience.
       </p>
       <span class="countdown-overlay-line countdown-overlay-line--bottom">to party</span>
+      <button class="countdown-overlay-skip" id="skipIntroButton" type="button">Skip intro</button>
       <span id="startInstructions" class="visually-hidden">This will start an interactive countdown and photo experience for Lorraine and Christopher's wedding celebration</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a skip intro control to the opening overlay so guests can jump directly to the event details
- style the skip button to match the existing theme while keeping it compact and anchored near the bottom of the screen
- update the JavaScript flow to hide the overlay and reveal the details immediately on both desktop and mobile when skipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2003b6474832eab941e87a9d39255